### PR TITLE
Remove EnergyOriginDateTimeExtension lib from eventstore

### DIFF
--- a/libraries/dotnet/EnergyOriginEventStore/EnergyOriginEventStore/EnergyOriginEventStore.csproj
+++ b/libraries/dotnet/EnergyOriginEventStore/EnergyOriginEventStore/EnergyOriginEventStore.csproj
@@ -15,7 +15,6 @@
 
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
-    <PackageReference Include="EnergyOriginDateTimeExtension" Version="1.2.0" />
     <PackageReference Include="Dapper.Extensions.PostgreSQL" Version="4.0.5" />
   </ItemGroup>
 

--- a/libraries/dotnet/EnergyOriginEventStore/EnergyOriginEventStore/EventStore/Serialization/InternalEvent.cs
+++ b/libraries/dotnet/EnergyOriginEventStore/EnergyOriginEventStore/EventStore/Serialization/InternalEvent.cs
@@ -1,16 +1,14 @@
-using EnergyOriginDateTimeExtension;
-
 namespace EnergyOriginEventStore.EventStore.Serialization;
 
 internal record InternalEvent(string Id, long Issued, long IssuedFraction, string ModelType, int ModelVersion, string Data)
 {
     internal static InternalEvent From(EventModel model)
     {
-        var now = DateTime.Now;
+        var now = DateTimeOffset.UtcNow;
 
         return new InternalEvent(
             Guid.NewGuid().ToString(),
-            now.ToUnixTime(),
+            now.ToUnixTimeSeconds(),
             now.Ticks,
             model.Type,
             model.Version,

--- a/libraries/dotnet/EnergyOriginEventStore/version.yaml
+++ b/libraries/dotnet/EnergyOriginEventStore/version.yaml
@@ -1,1 +1,1 @@
-version: 0.0.5
+version: 0.0.6


### PR DESCRIPTION
There is no need for the EnergyOriginDateTimeExtension. Furthermore, since EnergyOriginDateTimeExtension uses DateTime there is a risk that other developers will use DateTime when they should be using DateTimeOffset or Unix time instead. 
We need to get rid of it and let's start with this central component. 