### PR TITLE
Set ConcurrentMessageLimit to 1 for consumer

### DIFF
--- a/domains/certificates/Query.API/API/IntegrationEventBus/Startup.cs
+++ b/domains/certificates/Query.API/API/IntegrationEventBus/Startup.cs
@@ -12,7 +12,7 @@ public static class Startup
             o.SetKebabCaseEndpointNameFormatter();
 
             o.AddConsumer<EnergyMeasuredConsumer>(cc => cc.UseConcurrentMessageLimit(1));
-            
+
             o.UsingInMemory((context, cfg) => cfg.ConfigureEndpoints(context));
         });
 }

--- a/domains/certificates/Query.API/API/IntegrationEventBus/Startup.cs
+++ b/domains/certificates/Query.API/API/IntegrationEventBus/Startup.cs
@@ -1,4 +1,4 @@
-using System.Reflection;
+using API.GranularCertificateIssuer;
 using MassTransit;
 using Microsoft.Extensions.DependencyInjection;
 
@@ -11,9 +11,8 @@ public static class Startup
         {
             o.SetKebabCaseEndpointNameFormatter();
 
-            var entryAssembly = Assembly.GetEntryAssembly();
-            o.AddConsumers(entryAssembly);
-
+            o.AddConsumer<EnergyMeasuredConsumer>(cc => cc.UseConcurrentMessageLimit(1));
+            
             o.UsingInMemory((context, cfg) => cfg.ConfigureEndpoints(context));
         });
 }

--- a/domains/certificates/Query.API/chart-overrides.yaml
+++ b/domains/certificates/Query.API/chart-overrides.yaml
@@ -1,4 +1,4 @@
-version: 0.0.12
+version: 0.0.13
 versionPath: api.image.tag
 name: ghcr.io/energinet-datahub/eo-certificates-api
 namePath: api.image.name

--- a/domains/certificates/chart/Chart.yaml
+++ b/domains/certificates/chart/Chart.yaml
@@ -3,4 +3,4 @@ name: eo-certificates
 description: A chart containing the certificates domain.
 
 type: application
-version: 0.0.14
+version: 0.0.15


### PR DESCRIPTION
This should be seen as a work-around for https://app.zenhub.com/workspaces/team-atlas-633199659e255a37cd1d144f/issues/energinet-datahub/energy-origin-issues/1076. 

By only allowing 1 message at a time to the consumer we do not get into a situation where we will have multiple transactions completing at the same time. Multiple simultaneous transaction is a problem when there is a Marten projection executing inline (that is in the same transaction as the events). 