### PR TITLE
Add factory for DataSyncClient

### DIFF
--- a/domains/certificates/Query.API/API.UnitTests/DataSyncSyncer/DataSyncServiceTest.cs
+++ b/domains/certificates/Query.API/API.UnitTests/DataSyncSyncer/DataSyncServiceTest.cs
@@ -134,8 +134,11 @@ public class DataSyncServiceTest
 
     private DataSyncService SetupService()
     {
+        var fakeFactory = new Mock<IDataSyncClientFactory>();
+        fakeFactory.Setup(it => it.CreateClient()).Returns(fakeClient.Object);
+
         var service = new DataSyncService(
-            client: fakeClient.Object,
+            factory: fakeFactory.Object,
             logger: fakeLogger.Object,
             syncState: fakeSyncState.Object
         );

--- a/domains/certificates/Query.API/API/DataSyncSyncer/Client/DataSyncClientFactory.cs
+++ b/domains/certificates/Query.API/API/DataSyncSyncer/Client/DataSyncClientFactory.cs
@@ -1,0 +1,13 @@
+using System;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace API.DataSyncSyncer.Client;
+
+public class DataSyncClientFactory : IDataSyncClientFactory
+{
+    private readonly IServiceProvider serviceProvider;
+
+    public DataSyncClientFactory(IServiceProvider serviceProvider) => this.serviceProvider = serviceProvider;
+
+    public IDataSyncClient CreateClient() => serviceProvider.GetRequiredService<IDataSyncClient>();
+}

--- a/domains/certificates/Query.API/API/DataSyncSyncer/Client/IDataSyncClientFactory.cs
+++ b/domains/certificates/Query.API/API/DataSyncSyncer/Client/IDataSyncClientFactory.cs
@@ -1,4 +1,4 @@
-﻿namespace API.DataSyncSyncer.Client;
+namespace API.DataSyncSyncer.Client;
 
 public interface IDataSyncClientFactory
 {

--- a/domains/certificates/Query.API/API/DataSyncSyncer/Client/IDataSyncClientFactory.cs
+++ b/domains/certificates/Query.API/API/DataSyncSyncer/Client/IDataSyncClientFactory.cs
@@ -1,0 +1,6 @@
+﻿namespace API.DataSyncSyncer.Client;
+
+public interface IDataSyncClientFactory
+{
+    IDataSyncClient CreateClient();
+}

--- a/domains/certificates/Query.API/API/DataSyncSyncer/DataSyncService.cs
+++ b/domains/certificates/Query.API/API/DataSyncSyncer/DataSyncService.cs
@@ -13,14 +13,13 @@ namespace API.DataSyncSyncer;
 
 public class DataSyncService
 {
-    private readonly IDataSyncClient client;
+    private readonly IDataSyncClientFactory factory;
     private readonly ISyncState syncState;
-
     private readonly ILogger<DataSyncService> logger;
 
-    public DataSyncService(IDataSyncClient client, ILogger<DataSyncService> logger, ISyncState syncState)
+    public DataSyncService(IDataSyncClientFactory factory, ILogger<DataSyncService> logger, ISyncState syncState)
     {
-        this.client = client;
+        this.factory = factory;
         this.logger = logger;
         this.syncState = syncState;
     }
@@ -43,6 +42,7 @@ public class DataSyncService
         {
             try
             {
+                var client = factory.CreateClient();
                 var result = await client.RequestAsync(
                     masterData.GSRN,
                     new Period(

--- a/domains/certificates/Query.API/API/DataSyncSyncer/Startup.cs
+++ b/domains/certificates/Query.API/API/DataSyncSyncer/Startup.cs
@@ -20,7 +20,7 @@ public static class Startup
             var options = sp.GetRequiredService<IOptions<DatasyncOptions>>().Value;
             client.BaseAddress = new Uri(options.Url);
         });
-        
+
         services.AddSingleton<DataSyncService>();
         services.AddSingleton<ISyncState, SyncState>();
 

--- a/domains/certificates/Query.API/API/MasterDataService/Startup.cs
+++ b/domains/certificates/Query.API/API/MasterDataService/Startup.cs
@@ -22,12 +22,6 @@ public static class Startup
         services.AddHttpClient<AuthServiceClient>((sp, client) =>
         {
             var options = sp.GetRequiredService<IOptions<MockMasterDataOptions>>().Value;
-
-            if (string.IsNullOrWhiteSpace(options.AuthServiceUrl))
-            {
-                throw new Exception("No AuthServiceUrl");
-            }
-
             client.BaseAddress = new Uri(options.AuthServiceUrl);
         }).AddTransientHttpErrorPolicy(policy =>
             policy.WaitAndRetryAsync(new[]

--- a/domains/certificates/Query.API/chart-overrides.yaml
+++ b/domains/certificates/Query.API/chart-overrides.yaml
@@ -1,4 +1,4 @@
-version: 0.0.17
+version: 0.0.18
 versionPath: api.image.tag
 name: ghcr.io/energinet-datahub/eo-certificates-api
 namePath: api.image.name

--- a/domains/certificates/chart/Chart.yaml
+++ b/domains/certificates/chart/Chart.yaml
@@ -3,4 +3,4 @@ name: eo-certificates
 description: A chart containing the certificates domain.
 
 type: application
-version: 0.0.19
+version: 0.0.20


### PR DESCRIPTION
Why different approach for a http client? The main reason is that we need to be careful when its dependency is (captured as) singleton: 

* https://github.com/dotnet/runtime/issues/36067
* https://github.com/dotnet/AspNetCore.Docs/issues/10963

Based solution on https://www.stevejgordon.co.uk/ihttpclientfactory-patterns-using-typed-clients-from-singleton-services