### PR TITLE
Bugfix cache only valid owners masterdata

### DIFF
--- a/domains/certificates/Query.API/API/MasterDataService/MockMasterDataService.cs
+++ b/domains/certificates/Query.API/API/MasterDataService/MockMasterDataService.cs
@@ -58,7 +58,8 @@ internal class MockMasterDataService : IMasterDataService
 
         var meteringPointOwner = await clientFactory.CreateClient().GetUuidForCompany(cvr);
 
-        cvrToMeteringPointOwner.TryAdd(cvr, meteringPointOwner);
+        if (!string.IsNullOrWhiteSpace(meteringPointOwner))
+            cvrToMeteringPointOwner.TryAdd(cvr, meteringPointOwner);
 
         return meteringPointOwner;
     }

--- a/domains/certificates/Query.API/chart-overrides.yaml
+++ b/domains/certificates/Query.API/chart-overrides.yaml
@@ -1,4 +1,4 @@
-version: 1.0.1
+version: 1.0.2
 versionPath: api.image.tag
 name: ghcr.io/energinet-datahub/eo-certificates-api
 namePath: api.image.name

--- a/domains/certificates/chart/Chart.yaml
+++ b/domains/certificates/chart/Chart.yaml
@@ -3,4 +3,4 @@ name: eo-certificates
 description: A chart containing the certificates domain.
 
 type: application
-version: 1.0.1
+version: 1.0.2


### PR DESCRIPTION
`GetUuidForCompany` returns string.Empty when receving a not-ok answer from auth service. In this PR a check is added to ensure that MasterDataService only caches when there is a non empty string.