### PR TITLE
install xunit.analyzers v. 1.1.0

### DIFF
--- a/domains/certificates/Query.API/API.AppTests/API.AppTests.csproj
+++ b/domains/certificates/Query.API/API.AppTests/API.AppTests.csproj
@@ -16,6 +16,7 @@
     <PackageReference Include="Verify.Xunit" Version="17.10.2" />
     <PackageReference Include="WireMock.Net" Version="1.5.13" />
     <PackageReference Include="xunit" Version="2.4.2" />
+    <PackageReference Include="xunit.analyzers" Version="1.1.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>

--- a/domains/certificates/Query.API/chart-overrides.yaml
+++ b/domains/certificates/Query.API/chart-overrides.yaml
@@ -1,4 +1,4 @@
-version: 1.1.4
+version: 1.1.5
 versionPath: api.image.tag
 name: ghcr.io/energinet-datahub/eo-certificates-api
 namePath: api.image.name

--- a/domains/certificates/chart/Chart.yaml
+++ b/domains/certificates/chart/Chart.yaml
@@ -3,4 +3,4 @@ name: eo-certificates
 description: A chart containing the certificates domain.
 
 type: application
-version: 1.1.4
+version: 1.1.5


### PR DESCRIPTION
This should fix the false positive code smells from roslyn:xUnit1033 in https://sonarcloud.io/project/issues?resolved=false&types=CODE_SMELL&id=energinet-datahub_energy-origin_certificates

This appears to be the only fix to https://github.com/xunit/xunit/issues/2591; otherwise we have to wait for next release of xunit. 

