### PR TITLE
Fix null warnings in applicationdbcontext

### DIFF
--- a/domains/transfer/Transfer.API/API/Data/ApplicationDbContext.cs
+++ b/domains/transfer/Transfer.API/API/Data/ApplicationDbContext.cs
@@ -10,10 +10,10 @@ public class ApplicationDbContext : AuditDbContext
     {
     }
 
-    public DbSet<TransferAgreement> TransferAgreements { get; set; }
-    public DbSet<TransferAgreementHistoryEntry> TransferAgreementHistoryEntries { get; set; }
-    public DbSet<ConnectionInvitation> ConnectionInvitations { get; set; }
-    public DbSet<Connection> Connections { get; set; }
+    public DbSet<TransferAgreement> TransferAgreements { get; set; } = null!;
+    public DbSet<TransferAgreementHistoryEntry> TransferAgreementHistoryEntries { get; set; } = null!;
+    public DbSet<ConnectionInvitation> ConnectionInvitations { get; set; } = null!;
+    public DbSet<Connection> Connections { get; set; } = null!;
 
     protected override void OnModelCreating(ModelBuilder modelBuilder)
     {

--- a/domains/transfer/Transfer.API/configuration.yaml
+++ b/domains/transfer/Transfer.API/configuration.yaml
@@ -1,5 +1,5 @@
 name: eo-transfer-api
-version: 2.0.18
+version: 2.0.19
 repo: ghcr.io/energinet-datahub
 references:
   - file: k8s/energy-origin-apps/transfer/base/deployment.yaml


### PR DESCRIPTION
Compiler marks nullable dbcontexts as error. Suppressing in order to be able to build both locally, and in the pipeline.