### PR TITLE
Upgrade tokenvalidation in transfer

### DIFF
--- a/domains/transfer/ClaimAutomation/Worker.IntegrationTests/Worker.IntegrationTests.csproj
+++ b/domains/transfer/ClaimAutomation/Worker.IntegrationTests/Worker.IntegrationTests.csproj
@@ -23,7 +23,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
     <PackageReference Include="Testcontainers.PostgreSql" Version="3.7.0" />
     <PackageReference Include="Verify.Xunit" Version="22.11.5" />
-    <PackageReference Include="xunit" Version="2.6.5" />
+    <PackageReference Include="xunit" Version="2.6.6" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.5.6">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>

--- a/domains/transfer/ClaimAutomation/Worker.UnitTests/Worker.UnitTests.csproj
+++ b/domains/transfer/ClaimAutomation/Worker.UnitTests/Worker.UnitTests.csproj
@@ -13,7 +13,7 @@
     <PackageReference Include="FluentAssertions" Version="6.12.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
     <PackageReference Include="NSubstitute" Version="5.1.0" />
-    <PackageReference Include="xunit" Version="2.6.5" />
+    <PackageReference Include="xunit" Version="2.6.6" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.5.6">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>

--- a/domains/transfer/ClaimAutomation/Worker/Worker.csproj
+++ b/domains/transfer/ClaimAutomation/Worker/Worker.csproj
@@ -16,7 +16,7 @@
     <PackageReference Include="Asp.Versioning.Mvc" Version="8.0.0" />
     <PackageReference Include="Asp.Versioning.Mvc.ApiExplorer" Version="8.0.0" />
     <PackageReference Include="AspNetCore.HealthChecks.NpgSql" Version="8.0.0" />
-    <PackageReference Include="EnergyOrigin.TokenValidation" Version="3.0.2" />
+    <PackageReference Include="EnergyOrigin.TokenValidation" Version="3.0.3" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="8.0.1" />
     <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.7.0" />
     <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.7.0" />

--- a/domains/transfer/Transfer.API/API.IntegrationTests/API.IntegrationTests.csproj
+++ b/domains/transfer/Transfer.API/API.IntegrationTests/API.IntegrationTests.csproj
@@ -18,7 +18,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="EnergyOrigin.TokenValidation" Version="3.0.2" />
+        <PackageReference Include="EnergyOrigin.TokenValidation" Version="3.0.3" />
         <PackageReference Include="FluentAssertions" Version="6.12.0" />
         <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="8.0.1" />
         <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="8.0.1" />

--- a/domains/transfer/Transfer.API/API.IntegrationTests/API.IntegrationTests.csproj
+++ b/domains/transfer/Transfer.API/API.IntegrationTests/API.IntegrationTests.csproj
@@ -28,7 +28,7 @@
         <PackageReference Include="Verify" Version="22.11.5" />
         <PackageReference Include="Verify.Xunit" Version="22.11.5" />
         <PackageReference Include="WireMock.Net" Version="1.5.46" />
-        <PackageReference Include="xunit" Version="2.6.5" />
+        <PackageReference Include="xunit" Version="2.6.6" />
         <PackageReference Include="xunit.runner.visualstudio" Version="2.5.6">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>

--- a/domains/transfer/Transfer.API/API.UnitTests/API.UnitTests.csproj
+++ b/domains/transfer/Transfer.API/API.UnitTests/API.UnitTests.csproj
@@ -22,7 +22,7 @@
         <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="8.0.1" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
         <PackageReference Include="NSubstitute" Version="5.1.0" />
-        <PackageReference Include="xunit" Version="2.6.5" />
+        <PackageReference Include="xunit" Version="2.6.6" />
         <PackageReference Include="xunit.runner.visualstudio" Version="2.5.6">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>

--- a/domains/transfer/Transfer.API/API/API.csproj
+++ b/domains/transfer/Transfer.API/API/API.csproj
@@ -24,7 +24,7 @@
         <PackageReference Include="AspNetCore.HealthChecks.NpgSql" Version="8.0.0" />
         <PackageReference Include="Audit.EntityFramework.Core" Version="23.0.0" />
         <PackageReference Include="Audit.NET" Version="23.0.0" />
-        <PackageReference Include="EnergyOrigin.TokenValidation" Version="3.0.2" />
+        <PackageReference Include="EnergyOrigin.TokenValidation" Version="3.0.3" />
         <PackageReference Include="FluentValidation.AspNetCore" Version="11.3.0" />
         <PackageReference Include="IdentityModel" Version="6.2.0" />
         <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="8.0.1" />

--- a/domains/transfer/TransferAgreementAutomation/Worker.IntegrationTests/Worker.IntegrationTests.csproj
+++ b/domains/transfer/TransferAgreementAutomation/Worker.IntegrationTests/Worker.IntegrationTests.csproj
@@ -15,7 +15,7 @@
         <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="8.0.1" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
         <PackageReference Include="Verify.Xunit" Version="22.11.5" />
-        <PackageReference Include="xunit" Version="2.6.5" />
+        <PackageReference Include="xunit" Version="2.6.6" />
         <PackageReference Include="xunit.runner.visualstudio" Version="2.5.6">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>

--- a/domains/transfer/TransferAgreementAutomation/Worker.UnitTests/Worker.UnitTests.csproj
+++ b/domains/transfer/TransferAgreementAutomation/Worker.UnitTests/Worker.UnitTests.csproj
@@ -15,7 +15,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
     <PackageReference Include="NSubstitute" Version="5.1.0" />
     <PackageReference Include="RichardSzalay.MockHttp" Version="7.0.0" />
-    <PackageReference Include="xunit" Version="2.6.5" />
+    <PackageReference Include="xunit" Version="2.6.6" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.5.6">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>

--- a/domains/transfer/TransferAgreementAutomation/Worker/Worker.csproj
+++ b/domains/transfer/TransferAgreementAutomation/Worker/Worker.csproj
@@ -16,7 +16,7 @@
     <PackageReference Include="Asp.Versioning.Mvc" Version="8.0.0" />
     <PackageReference Include="Asp.Versioning.Mvc.ApiExplorer" Version="8.0.0" />
     <PackageReference Include="AspNetCore.HealthChecks.NpgSql" Version="8.0.0" />
-    <PackageReference Include="EnergyOrigin.TokenValidation" Version="3.0.2" />
+    <PackageReference Include="EnergyOrigin.TokenValidation" Version="3.0.3" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="8.0.1" />
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.1" />
     <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.7.0" />


### PR DESCRIPTION
TokenValidation was upgraded to 3.0.3

Package upgrade will be included in the pr's, for certificates, and measurements NuGet package Upgrade