### PR TITLE
Fix verify breaking change in transfer

### DIFF
--- a/domains/transfer/ClaimAutomation/Worker.IntegrationTests/SwaggerTests.cs
+++ b/domains/transfer/ClaimAutomation/Worker.IntegrationTests/SwaggerTests.cs
@@ -4,12 +4,10 @@ using System.Threading.Tasks;
 using FluentAssertions;
 using Microsoft.AspNetCore.Hosting;
 using VerifyXunit;
-using Worker.IntegrationTests;
 using Xunit;
 
-namespace Worker.IntegrationTest;
+namespace Worker.IntegrationTests;
 
-[UsesVerify]
 public class SwaggerTests : IClassFixture<ClaimAutomationApplicationFactory>
 {
     private readonly ClaimAutomationApplicationFactory factory;

--- a/domains/transfer/ClaimAutomation/Worker.IntegrationTests/Worker.IntegrationTests.csproj
+++ b/domains/transfer/ClaimAutomation/Worker.IntegrationTests/Worker.IntegrationTests.csproj
@@ -22,7 +22,7 @@
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="8.0.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
     <PackageReference Include="Testcontainers.PostgreSql" Version="3.7.0" />
-    <PackageReference Include="Verify.Xunit" Version="22.11.5" />
+    <PackageReference Include="Verify.Xunit" Version="23.0.0" />
     <PackageReference Include="xunit" Version="2.6.6" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.5.6">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/domains/transfer/Transfer.API/API.IntegrationTests/API.IntegrationTests.csproj
+++ b/domains/transfer/Transfer.API/API.IntegrationTests/API.IntegrationTests.csproj
@@ -25,8 +25,8 @@
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
         <PackageReference Include="NSubstitute" Version="5.1.0" />
         <PackageReference Include="Testcontainers.PostgreSql" Version="3.7.0" />
-        <PackageReference Include="Verify" Version="22.11.5" />
-        <PackageReference Include="Verify.Xunit" Version="22.11.5" />
+        <PackageReference Include="Verify" Version="23.0.0" />
+        <PackageReference Include="Verify.Xunit" Version="23.0.0" />
         <PackageReference Include="WireMock.Net" Version="1.5.46" />
         <PackageReference Include="xunit" Version="2.6.6" />
         <PackageReference Include="xunit.runner.visualstudio" Version="2.5.6">

--- a/domains/transfer/Transfer.API/API.IntegrationTests/Cvr/Api/v2023_01_01/Controllers/CvrControllerTests.cs
+++ b/domains/transfer/Transfer.API/API.IntegrationTests/Cvr/Api/v2023_01_01/Controllers/CvrControllerTests.cs
@@ -14,7 +14,6 @@ using Xunit;
 
 namespace API.IntegrationTests.Cvr.Api.v2023_01_01.Controllers;
 
-[UsesVerify]
 public class CvrControllerTests : IClassFixture<TransferAgreementsApiWebApplicationFactory>
 {
     private readonly TransferAgreementsApiWebApplicationFactory factory;

--- a/domains/transfer/Transfer.API/API.IntegrationTests/Cvr/Api/v2024_01_03/Controllers/CvrControllerTests.cs
+++ b/domains/transfer/Transfer.API/API.IntegrationTests/Cvr/Api/v2024_01_03/Controllers/CvrControllerTests.cs
@@ -16,7 +16,6 @@ using Xunit;
 
 namespace API.IntegrationTests.Cvr.Api.v2024_01_03.Controllers;
 
-[UsesVerify]
 public class CvrControllerTests : IClassFixture<TransferAgreementsApiWebApplicationFactory>
 {
     private readonly TransferAgreementsApiWebApplicationFactory factory;

--- a/domains/transfer/Transfer.API/API.IntegrationTests/Cvr/Api/v2024_01_03/Controllers/CvrMultipleResponseTests.cs
+++ b/domains/transfer/Transfer.API/API.IntegrationTests/Cvr/Api/v2024_01_03/Controllers/CvrMultipleResponseTests.cs
@@ -17,7 +17,6 @@ using Xunit;
 namespace API.IntegrationTests.Cvr.Api.v2024_01_03.Controllers;
 //WireMock has issues running parallel tests, where different response bodies from different json files have to be used.
 //In order to circumvent this, and make sure WireMock is not using resources from other tests,it has been put in a separate Class.
-[UsesVerify]
 public class CvrMultipleResponseTests : IClassFixture<TransferAgreementsApiWebApplicationFactory>
 {
     private readonly TransferAgreementsApiWebApplicationFactory factory;

--- a/domains/transfer/Transfer.API/API.IntegrationTests/SwaggerTests.cs
+++ b/domains/transfer/Transfer.API/API.IntegrationTests/SwaggerTests.cs
@@ -9,7 +9,6 @@ using Xunit;
 
 namespace API.IntegrationTests;
 
-[UsesVerify]
 public class SwaggerTests : IClassFixture<TransferAgreementsApiWebApplicationFactory>
 {
     private readonly TransferAgreementsApiWebApplicationFactory factory;

--- a/domains/transfer/Transfer.API/API.IntegrationTests/Transfer/Api/v2023_01_01/Controllers/TransferAgreementHistoryEntriesControllerTests.cs
+++ b/domains/transfer/Transfer.API/API.IntegrationTests/Transfer/Api/v2023_01_01/Controllers/TransferAgreementHistoryEntriesControllerTests.cs
@@ -19,7 +19,6 @@ using Xunit;
 
 namespace API.IntegrationTests.Transfer.Api.v2023_01_01.Controllers;
 
-[UsesVerify]
 public class TransferAgreementHistoryEntriesControllerTests : IClassFixture<TransferAgreementsApiWebApplicationFactory>
 {
     private readonly TransferAgreementsApiWebApplicationFactory factory;

--- a/domains/transfer/Transfer.API/API.IntegrationTests/Transfer/Api/v2023_01_01/Controllers/TransferAgreementsControllerTest.cs
+++ b/domains/transfer/Transfer.API/API.IntegrationTests/Transfer/Api/v2023_01_01/Controllers/TransferAgreementsControllerTest.cs
@@ -20,7 +20,6 @@ using Xunit.Abstractions;
 
 namespace API.IntegrationTests.Transfer.Api.v2023_01_01.Controllers;
 
-[UsesVerify]
 public class TransferAgreementsControllerTests : IClassFixture<TransferAgreementsApiWebApplicationFactory>
 {
     private readonly TransferAgreementsApiWebApplicationFactory factory;

--- a/domains/transfer/Transfer.API/API.IntegrationTests/Transfer/Api/v2023_11_23/Controllers/InternalTransferAgreementsControllerTest.cs
+++ b/domains/transfer/Transfer.API/API.IntegrationTests/Transfer/Api/v2023_11_23/Controllers/InternalTransferAgreementsControllerTest.cs
@@ -12,7 +12,6 @@ using Xunit;
 
 namespace API.IntegrationTests.Transfer.Api.v2023_11_23.Controllers;
 
-[UsesVerify]
 public class InternalTransferAgreementsControllerTests : IClassFixture<TransferAgreementsApiWebApplicationFactory>
 {
     private readonly TransferAgreementsApiWebApplicationFactory factory;

--- a/domains/transfer/Transfer.API/API.IntegrationTests/Transfer/Api/v2023_11_23/Controllers/TransferAgreementHistoryEntriesControllerTests.cs
+++ b/domains/transfer/Transfer.API/API.IntegrationTests/Transfer/Api/v2023_11_23/Controllers/TransferAgreementHistoryEntriesControllerTests.cs
@@ -18,7 +18,6 @@ using Xunit;
 
 namespace API.IntegrationTests.Transfer.Api.v2023_11_23.Controllers;
 
-[UsesVerify]
 public class TransferAgreementHistoryEntriesControllerTests : IClassFixture<TransferAgreementsApiWebApplicationFactory>
 {
     private readonly TransferAgreementsApiWebApplicationFactory factory;

--- a/domains/transfer/Transfer.API/API.IntegrationTests/Transfer/Api/v2023_11_23/Controllers/TransferAgreementsControllerTest.cs
+++ b/domains/transfer/Transfer.API/API.IntegrationTests/Transfer/Api/v2023_11_23/Controllers/TransferAgreementsControllerTest.cs
@@ -22,7 +22,6 @@ using TransferAgreementsResponse = API.Transfer.Api.v2023_01_01.Dto.Responses.Tr
 
 namespace API.IntegrationTests.Transfer.Api.v2023_11_23.Controllers;
 
-[UsesVerify]
 public class TransferAgreementsControllerTests : IClassFixture<TransferAgreementsApiWebApplicationFactory>
 {
     private readonly TransferAgreementsApiWebApplicationFactory factory;

--- a/domains/transfer/TransferAgreementAutomation/Worker.IntegrationTests/SwaggerTests.cs
+++ b/domains/transfer/TransferAgreementAutomation/Worker.IntegrationTests/SwaggerTests.cs
@@ -8,7 +8,6 @@ using Xunit;
 
 namespace Worker.IntegrationTest;
 
-[UsesVerify]
 public class SwaggerTests : IClassFixture<TransferAutomationApplicationFactory>
 {
     private readonly TransferAutomationApplicationFactory factory;

--- a/domains/transfer/TransferAgreementAutomation/Worker.IntegrationTests/Worker.IntegrationTests.csproj
+++ b/domains/transfer/TransferAgreementAutomation/Worker.IntegrationTests/Worker.IntegrationTests.csproj
@@ -14,7 +14,7 @@
         <PackageReference Include="FluentAssertions" Version="6.12.0" />
         <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="8.0.1" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
-        <PackageReference Include="Verify.Xunit" Version="22.11.5" />
+        <PackageReference Include="Verify.Xunit" Version="23.0.0" />
         <PackageReference Include="xunit" Version="2.6.6" />
         <PackageReference Include="xunit.runner.visualstudio" Version="2.5.6">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>


### PR DESCRIPTION
Verify latest version came with breaking changes, that needs to be fixed, in transfer.

The fix will be applied in other subsystems, along with their NuGet Package upgrades

Documentation:

https://github.com/VerifyTests/Verify/pull/1131