### PR TITLE
Add grpc tracing to workers in transfer

### DIFF
--- a/domains/transfer/ClaimAutomation/Worker/Program.cs
+++ b/domains/transfer/ClaimAutomation/Worker/Program.cs
@@ -86,6 +86,7 @@ builder.Services.AddGrpcClient<WalletService.WalletServiceClient>((sp, o) =>
     var options = sp.GetRequiredService<IOptions<ProjectOriginOptions>>().Value;
     o.Address = new Uri(options.WalletUrl);
 });
+
 builder.Services.AddApiVersioning(options =>
     {
         options.AssumeDefaultVersionWhenUnspecified = false;
@@ -94,10 +95,11 @@ builder.Services.AddApiVersioning(options =>
     })
     .AddMvc()
     .AddApiExplorer();
+
 builder.Services.AddTransient<IConfigureOptions<SwaggerGenOptions>, ConfigureSwaggerOptions>();
 builder.Services.AddSwaggerGen();
-var tokenValidationOptions = builder.Configuration.GetSection(TokenValidationOptions.Prefix).Get<TokenValidationOptions>()!;
 
+var tokenValidationOptions = builder.Configuration.GetSection(TokenValidationOptions.Prefix).Get<TokenValidationOptions>()!;
 builder.AddTokenValidation(tokenValidationOptions);
 
 builder.Services.AddOpenTelemetry()

--- a/domains/transfer/ClaimAutomation/Worker/Program.cs
+++ b/domains/transfer/ClaimAutomation/Worker/Program.cs
@@ -113,6 +113,14 @@ builder.Services.AddOpenTelemetry()
             .AddOtlpExporter(o => o.Endpoint = otlpOptions.ReceiverEndpoint))
     .WithTracing(tracerProviderBuilder =>
         tracerProviderBuilder
+            .AddGrpcClientInstrumentation(grpcOptions =>
+            {
+                grpcOptions.SuppressDownstreamInstrumentation = true;
+                grpcOptions.EnrichWithHttpRequestMessage = (activity, httpRequestMessage) =>
+                    activity.SetTag("requestVersion", httpRequestMessage.Version);
+                grpcOptions.EnrichWithHttpResponseMessage = (activity, httpResponseMessage) =>
+                    activity.SetTag("responseVersion", httpResponseMessage.Version);
+            })
             .AddHttpClientInstrumentation()
             .AddAspNetCoreInstrumentation()
             .AddNpgsql()

--- a/domains/transfer/ClaimAutomation/Worker/Worker.csproj
+++ b/domains/transfer/ClaimAutomation/Worker/Worker.csproj
@@ -22,6 +22,7 @@
     <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.7.0" />
     <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.7.0" />
     <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.7.0" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.GrpcNetClient" Version="1.6.0-beta.3" />
     <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.7.0" />
     <PackageReference Include="OpenTelemetry.Instrumentation.Process" Version="0.5.0-beta.2" />
     <PackageReference Include="OpenTelemetry.Instrumentation.Runtime" Version="1.7.0" />

--- a/domains/transfer/Transfer.API/API/Program.cs
+++ b/domains/transfer/Transfer.API/API/Program.cs
@@ -78,7 +78,6 @@ builder.Services.AddSwaggerGen();
 builder.Services.AddOptions<OtlpOptions>().BindConfiguration(OtlpOptions.Prefix).ValidateDataAnnotations()
     .ValidateOnStart();
 
-
 builder.Services.AddOpenTelemetry()
     .ConfigureResource(resource => resource
         .AddService(serviceName: "Transfer.API"))
@@ -94,7 +93,6 @@ builder.Services.AddOpenTelemetry()
         .AddAspNetCoreInstrumentation()
         .AddNpgsql()
         .AddOtlpExporter(o => o.Endpoint = otlpOptions.ReceiverEndpoint));
-
 
 var tokenValidationOptions = builder.Configuration.GetSection(TokenValidationOptions.Prefix).Get<TokenValidationOptions>()!;
 builder.Services.AddOptions<TokenValidationOptions>().BindConfiguration(TokenValidationOptions.Prefix).ValidateDataAnnotations().ValidateOnStart();

--- a/domains/transfer/Transfer.API/API/Transfer/Startup.cs
+++ b/domains/transfer/Transfer.API/API/Transfer/Startup.cs
@@ -56,11 +56,9 @@ public static class Startup
                                     break;
                                 }
                         }
-
                         return true;
                     })
                 ));
-
 
         services.AddScoped<ITransferAgreementRepository, TransferAgreementRepository>();
         services.AddScoped<IProjectOriginWalletService, ProjectOriginWalletService>();

--- a/domains/transfer/TransferAgreementAutomation/Worker/Program.cs
+++ b/domains/transfer/TransferAgreementAutomation/Worker/Program.cs
@@ -25,7 +25,6 @@ using TransferAgreementAutomation.Worker.Options;
 using TransferAgreementAutomation.Worker.Service;
 using TransferAgreementAutomation.Worker.Swagger;
 
-
 var builder = WebApplication.CreateBuilder(args);
 
 var otlpConfiguration = builder.Configuration.GetSection(OtlpOptions.Prefix);

--- a/domains/transfer/TransferAgreementAutomation/Worker/Program.cs
+++ b/domains/transfer/TransferAgreementAutomation/Worker/Program.cs
@@ -68,6 +68,14 @@ builder.Services.AddOpenTelemetry()
             .AddOtlpExporter(o => o.Endpoint = otlpOptions.ReceiverEndpoint))
     .WithTracing(tracerProviderBuilder =>
         tracerProviderBuilder
+            .AddGrpcClientInstrumentation(grpcOptions =>
+            {
+                grpcOptions.SuppressDownstreamInstrumentation = true;
+                grpcOptions.EnrichWithHttpRequestMessage = (activity, httpRequestMessage) =>
+                    activity.SetTag("requestVersion", httpRequestMessage.Version);
+                grpcOptions.EnrichWithHttpResponseMessage = (activity, httpResponseMessage) =>
+                    activity.SetTag("responseVersion", httpResponseMessage.Version);
+            })
             .AddHttpClientInstrumentation()
             .AddAspNetCoreInstrumentation()
             .AddNpgsql()

--- a/domains/transfer/TransferAgreementAutomation/Worker/Worker.csproj
+++ b/domains/transfer/TransferAgreementAutomation/Worker/Worker.csproj
@@ -23,6 +23,7 @@
     <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.7.0" />
     <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.7.0" />
     <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.7.0" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.GrpcNetClient" Version="1.6.0-beta.3" />
     <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.7.0" />
     <PackageReference Include="OpenTelemetry.Instrumentation.Process" Version="0.5.0-beta.2" />
     <PackageReference Include="OpenTelemetry.Instrumentation.Runtime" Version="1.7.0" />


### PR DESCRIPTION
Jaeger was not displaying all traces from the workers because OpenTelemetry was not collecting traces from Grpc clients used in TransferAutomation, and ClaimAutomation. That has now been fixed.