### PR TITLE
Add Grpc instrumentation for RegistryConnector

### DIFF
--- a/domains/certificates/RegistryConnector/Worker/Program.cs
+++ b/domains/certificates/RegistryConnector/Worker/Program.cs
@@ -102,7 +102,6 @@ builder.Services.AddMassTransit(o =>
     o.AddEntityFrameworkOutbox<ApplicationDbContext>(outboxConfigurator =>
     {
         outboxConfigurator.UsePostgres();
-
         outboxConfigurator.UseBusOutbox();
     });
 });
@@ -112,7 +111,6 @@ void ConfigureResource(ResourceBuilder r)
     r.AddService("RegistryConnector",
         serviceInstanceId: Environment.MachineName);
 }
-
 
 builder.Services.AddOpenTelemetry()
     .ConfigureResource(ConfigureResource)

--- a/domains/certificates/RegistryConnector/Worker/Program.cs
+++ b/domains/certificates/RegistryConnector/Worker/Program.cs
@@ -126,6 +126,14 @@ builder.Services.AddOpenTelemetry()
             .AddOtlpExporter(o => o.Endpoint = otlpOptions.ReceiverEndpoint))
     .WithTracing(tracerProviderBuilder =>
         tracerProviderBuilder
+            .AddGrpcClientInstrumentation(grpcOptions =>
+            {
+                grpcOptions.EnrichWithHttpRequestMessage = (activity, httpRequestMessage) =>
+                    activity.SetTag("requestVersion", httpRequestMessage.Version);
+                grpcOptions.EnrichWithHttpResponseMessage = (activity, httpResponseMessage) =>
+                    activity.SetTag("responseVersion", httpResponseMessage.Version);
+                grpcOptions.SuppressDownstreamInstrumentation = true;
+            })
             .AddHttpClientInstrumentation()
             .AddAspNetCoreInstrumentation()
             .AddNpgsql()

--- a/domains/certificates/RegistryConnector/Worker/Program.cs
+++ b/domains/certificates/RegistryConnector/Worker/Program.cs
@@ -128,11 +128,11 @@ builder.Services.AddOpenTelemetry()
         tracerProviderBuilder
             .AddGrpcClientInstrumentation(grpcOptions =>
             {
+                grpcOptions.SuppressDownstreamInstrumentation = true;
                 grpcOptions.EnrichWithHttpRequestMessage = (activity, httpRequestMessage) =>
                     activity.SetTag("requestVersion", httpRequestMessage.Version);
                 grpcOptions.EnrichWithHttpResponseMessage = (activity, httpResponseMessage) =>
                     activity.SetTag("responseVersion", httpResponseMessage.Version);
-                grpcOptions.SuppressDownstreamInstrumentation = true;
             })
             .AddHttpClientInstrumentation()
             .AddAspNetCoreInstrumentation()

--- a/domains/certificates/RegistryConnector/Worker/Worker.csproj
+++ b/domains/certificates/RegistryConnector/Worker/Worker.csproj
@@ -18,6 +18,7 @@
 		<PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.7.0" />
 		<PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.7.0" />
 		<PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.7.0" />
+		<PackageReference Include="OpenTelemetry.Instrumentation.GrpcNetClient" Version="1.6.0-beta.3" />
 		<PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.7.0" />
 		<PackageReference Include="OpenTelemetry.Instrumentation.Process" Version="0.5.0-beta.2" />
 		<PackageReference Include="OpenTelemetry.Instrumentation.Runtime" Version="1.7.0" />


### PR DESCRIPTION
Jaeger was not displaying all traces from the RegustryConnector, because OpenTelemetry was not collecting traces from service that use Grpc. That has now been fixed.