### PR TITLE
change enum types to string repr. in API

### DIFF
--- a/domains/certificates/Query.API/API.IntegrationTests/SwaggerTests.GetSwaggerDocs_v20230101.verified.txt
+++ b/domains/certificates/Query.API/API.IntegrationTests/SwaggerTests.GetSwaggerDocs_v20230101.verified.txt
@@ -273,13 +273,13 @@
         "type": "object",
         "properties": {
           "start": {
-            "type": "string",
-            "format": "date-time",
+            "type": "integer",
+            "format": "int64",
             "nullable": true
           },
           "end": {
-            "type": "string",
-            "format": "date-time",
+            "type": "integer",
+            "format": "int64",
             "nullable": true
           },
           "entityType": {

--- a/domains/certificates/Query.API/API/Program.cs
+++ b/domains/certificates/Query.API/API/Program.cs
@@ -19,6 +19,7 @@ using DataContext;
 using EnergyOrigin.ActivityLog;
 using EnergyOrigin.TokenValidation.Options;
 using EnergyOrigin.TokenValidation.Utilities;
+using Microsoft.AspNetCore.Http.Json;
 using Npgsql;
 using OpenTelemetry.Resources;
 using OpenTelemetry.Trace;
@@ -62,6 +63,8 @@ builder.Services.AddOpenTelemetry()
             .AddAspNetCoreInstrumentation()
             .AddNpgsql()
             .AddOtlpExporter(o => o.Endpoint = otlpOptions.ReceiverEndpoint));
+
+builder.Services.Configure<JsonOptions>(options => options.SerializerOptions.Converters.Add(new JsonStringEnumConverter()));
 
 builder.Services.AddControllers()
     .AddJsonOptions(o =>

--- a/domains/certificates/Shared/DataContext/DataContext.csproj
+++ b/domains/certificates/Shared/DataContext/DataContext.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="EnergyOrigin.ActivityLog" Version="3.0.10" />
+    <PackageReference Include="EnergyOrigin.ActivityLog" Version="3.0.11" />
     <PackageReference Include="MassTransit.EntityFrameworkCore" Version="8.1.3" />
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.1" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.1">

--- a/domains/transfer/Shared/DataContext/DataContext.csproj
+++ b/domains/transfer/Shared/DataContext/DataContext.csproj
@@ -8,7 +8,7 @@
 
   <ItemGroup>
     <PackageReference Include="Audit.EntityFramework.Core" Version="23.0.0" />
-    <PackageReference Include="EnergyOrigin.ActivityLog" Version="3.0.10" />
+    <PackageReference Include="EnergyOrigin.ActivityLog" Version="3.0.11" />
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.1" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.1">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/domains/transfer/Transfer.API/API.IntegrationTests/SwaggerTests.GetSwaggerDocs_v20230101.verified.txt
+++ b/domains/transfer/Transfer.API/API.IntegrationTests/SwaggerTests.GetSwaggerDocs_v20230101.verified.txt
@@ -602,13 +602,13 @@
         "type": "object",
         "properties": {
           "start": {
-            "type": "string",
-            "format": "date-time",
+            "type": "integer",
+            "format": "int64",
             "nullable": true
           },
           "end": {
-            "type": "string",
-            "format": "date-time",
+            "type": "integer",
+            "format": "int64",
             "nullable": true
           },
           "entityType": {

--- a/domains/transfer/Transfer.API/API.IntegrationTests/SwaggerTests.GetSwaggerDocs_v20231123.verified.txt
+++ b/domains/transfer/Transfer.API/API.IntegrationTests/SwaggerTests.GetSwaggerDocs_v20231123.verified.txt
@@ -612,13 +612,13 @@
         "type": "object",
         "properties": {
           "start": {
-            "type": "string",
-            "format": "date-time",
+            "type": "integer",
+            "format": "int64",
             "nullable": true
           },
           "end": {
-            "type": "string",
-            "format": "date-time",
+            "type": "integer",
+            "format": "int64",
             "nullable": true
           },
           "entityType": {

--- a/domains/transfer/Transfer.API/API.IntegrationTests/SwaggerTests.GetSwaggerDocs_v20240103.verified.txt
+++ b/domains/transfer/Transfer.API/API.IntegrationTests/SwaggerTests.GetSwaggerDocs_v20240103.verified.txt
@@ -1126,13 +1126,13 @@
         "type": "object",
         "properties": {
           "start": {
-            "type": "string",
-            "format": "date-time",
+            "type": "integer",
+            "format": "int64",
             "nullable": true
           },
           "end": {
-            "type": "string",
-            "format": "date-time",
+            "type": "integer",
+            "format": "int64",
             "nullable": true
           },
           "entityType": {

--- a/domains/transfer/Transfer.API/API/Program.cs
+++ b/domains/transfer/Transfer.API/API/Program.cs
@@ -11,6 +11,7 @@ using EnergyOrigin.TokenValidation.Options;
 using EnergyOrigin.TokenValidation.Utilities;
 using FluentValidation;
 using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http.Json;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
@@ -59,6 +60,8 @@ builder.Services.AddHealthChecks()
     .AddNpgSql(sp => sp.GetRequiredService<IOptions<DatabaseOptions>>().Value.ToConnectionString());
 
 builder.Services.AddValidatorsFromAssembly(typeof(Program).Assembly);
+
+builder.Services.Configure<JsonOptions>(options => options.SerializerOptions.Converters.Add(new JsonStringEnumConverter()));
 
 builder.Services.AddActivityLog(options => options.ServiceName = "transfer");
 


### PR DESCRIPTION
This involves bumping to latest activity log nuget package and setting json enum converter to use string representation globally.