### PR TITLE
Add swagger for redocly import

### DIFF
--- a/domains/certificates/Query.API/API.IntegrationTests/API.IntegrationTests.csproj
+++ b/domains/certificates/Query.API/API.IntegrationTests/API.IntegrationTests.csproj
@@ -1,48 +1,53 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
-    <ImplicitUsings>disable</ImplicitUsings>
-    <Nullable>enable</Nullable>
+    <PropertyGroup>
+        <TargetFramework>net8.0</TargetFramework>
+        <ImplicitUsings>disable</ImplicitUsings>
+        <Nullable>enable</Nullable>
 
-    <IsPackable>false</IsPackable>
-  </PropertyGroup>
+        <IsPackable>false</IsPackable>
+    </PropertyGroup>
 
-  <PropertyGroup Condition="$(CI) == true">
-    <DefineConstants>CI</DefineConstants>
-  </PropertyGroup>
+    <PropertyGroup Condition="$(CI) == true">
+        <DefineConstants>CI</DefineConstants>
+    </PropertyGroup>
 
-  <ItemGroup>
-    <PackageReference Include="FluentAssertions" Version="6.12.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="8.0.2" />
-    <PackageReference Include="Microsoft.CodeAnalysis" Version="4.9.2" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.2" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
-    <PackageReference Include="NSubstitute" Version="5.1.0" />
-    <PackageReference Include="Testcontainers" Version="3.7.0" />
-    <PackageReference Include="Testcontainers.PostgreSql" Version="3.7.0" />
-    <PackageReference Include="Testcontainers.RabbitMq" Version="3.7.0" />
-    <PackageReference Include="Verify.Xunit" Version="23.3.0" />
-    <PackageReference Include="WireMock.Net" Version="1.5.49" />
-    <PackageReference Include="xunit" Version="2.7.0" />
-    <PackageReference Include="xunit.analyzers" Version="1.11.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.7">
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-      <PrivateAssets>all</PrivateAssets>
-    </PackageReference>
-    <PackageReference Include="coverlet.collector" Version="6.0.1">
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-      <PrivateAssets>all</PrivateAssets>
-    </PackageReference>
-  </ItemGroup>
+    <ItemGroup>
+        <PackageReference Include="FluentAssertions" Version="6.12.0" />
+        <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="8.0.2" />
+        <PackageReference Include="Microsoft.CodeAnalysis" Version="4.9.2" />
+        <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.2" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
+        <PackageReference Include="NSubstitute" Version="5.1.0" />
+        <PackageReference Include="Testcontainers" Version="3.7.0" />
+        <PackageReference Include="Testcontainers.PostgreSql" Version="3.7.0" />
+        <PackageReference Include="Testcontainers.RabbitMq" Version="3.7.0" />
+        <PackageReference Include="Verify.Xunit" Version="23.3.0" />
+        <PackageReference Include="WireMock.Net" Version="1.5.49" />
+        <PackageReference Include="xunit" Version="2.7.0" />
+        <PackageReference Include="xunit.analyzers" Version="1.11.0" />
+        <PackageReference Include="xunit.runner.visualstudio" Version="2.5.7">
+            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+            <PrivateAssets>all</PrivateAssets>
+        </PackageReference>
+        <PackageReference Include="coverlet.collector" Version="6.0.1">
+            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+            <PrivateAssets>all</PrivateAssets>
+        </PackageReference>
+    </ItemGroup>
 
-  <ItemGroup>
-    <ProjectReference Include="..\..\RegistryConnector\Worker\Worker.csproj">
-      <Aliases>registryConnector</Aliases>
-    </ProjectReference>
-    <ProjectReference Include="..\..\Shared\DataContext\DataContext.csproj" />
-    <ProjectReference Include="..\..\Shared\Testing\Testing.csproj" />
-    <ProjectReference Include="..\API\API.csproj" />
-  </ItemGroup>
+    <ItemGroup>
+        <None Update="Query.API/API.IntegrationTests/SwaggerTests.swagger.json.verified.txt">
+            <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+        </None>
+    </ItemGroup>
 
+    <ItemGroup>
+        <ProjectReference Include="..\..\RegistryConnector\Worker\Worker.csproj">
+            <Aliases>registryConnector</Aliases>
+        </ProjectReference>
+        <ProjectReference Include="..\..\Shared\DataContext\DataContext.csproj" />
+        <ProjectReference Include="..\..\Shared\Testing\Testing.csproj" />
+        <ProjectReference Include="..\API\API.csproj" />
+    </ItemGroup>
 </Project>

--- a/domains/certificates/Query.API/API.IntegrationTests/SwaggerTests.cs
+++ b/domains/certificates/Query.API/API.IntegrationTests/SwaggerTests.cs
@@ -186,6 +186,29 @@ public class SwaggerTests(QueryApiWebApplicationFactory factory) : TestBase, ICl
     }
 
     [Fact]
+    public async Task GetSwaggerDoc_AppStarted_LatestVersionNoChangesAccordingToSnapshot()
+    {
+        using var client = factory.CreateClient();
+
+        var provider = factory.GetApiVersionDescriptionProvider();
+
+        var latestVersion = provider.ApiVersionDescriptions
+            .OrderByDescending(v => v.ApiVersion)
+            .Select(v => v.GroupName)
+            .FirstOrDefault();
+
+        var swaggerDocUrl = $"api-docs/certificates/{latestVersion}/swagger.json";
+        var response = await client.GetAsync(swaggerDocUrl);
+
+        response.EnsureSuccessStatusCode();
+
+        var json = await response.Content.ReadAsStringAsync();
+        await Verifier.Verify(json)
+            .UseParameters(latestVersion)
+            .UseMethodName($"swagger.json");
+    }
+
+    [Fact]
     public async Task SwaggerJson_ForAllVersions_ContainsContractsTag()
     {
         using var client = factory.CreateClient();

--- a/domains/certificates/Query.API/API.IntegrationTests/SwaggerTests.swagger.json.verified.txt
+++ b/domains/certificates/Query.API/API.IntegrationTests/SwaggerTests.swagger.json.verified.txt
@@ -1,0 +1,523 @@
+{
+  "openapi": "3.0.1",
+  "info": {
+    "title": "Certificates Query API 20230101",
+    "description": "",
+    "version": "20230101"
+  },
+  "paths": {
+    "/api/certificates/activity-log": {
+      "post": {
+        "tags": [
+          "Activity log"
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ActivityLogEntryFilterRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ActivityLogListEntryResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/certificates/contracts": {
+      "post": {
+        "tags": [
+          "Contracts"
+        ],
+        "summary": "Create a contract that activates granular certificate generation for a metering point",
+        "parameters": [
+          {
+            "name": "EO_API_VERSION",
+            "in": "header",
+            "description": "The requested API version",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "default": "20230101"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CreateContract"
+              }
+            },
+            "text/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CreateContract"
+              }
+            },
+            "application/*+json": {
+              "schema": {
+                "$ref": "#/components/schemas/CreateContract"
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Created"
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ValidationProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ValidationProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ValidationProblemDetails"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Conflict"
+          }
+        }
+      },
+      "get": {
+        "tags": [
+          "Contracts"
+        ],
+        "summary": "Returns all the user's contracts for issuing granular certificates",
+        "parameters": [
+          {
+            "name": "EO_API_VERSION",
+            "in": "header",
+            "description": "The requested API version",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "default": "20230101"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ContractList"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ContractList"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ContractList"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/certificates/contracts/{id}": {
+      "get": {
+        "tags": [
+          "Contracts"
+        ],
+        "summary": "Returns contract based on the id",
+        "operationId": "GetContract",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          },
+          {
+            "name": "EO_API_VERSION",
+            "in": "header",
+            "description": "The requested API version",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "default": "20230101"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/Contract"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Contract"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Contract"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found"
+          }
+        }
+      },
+      "put": {
+        "tags": [
+          "Contracts"
+        ],
+        "summary": "Edit the end date for contract",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          },
+          {
+            "name": "EO_API_VERSION",
+            "in": "header",
+            "description": "The requested API version",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "default": "20230101"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/EditContractEndDate"
+              }
+            },
+            "text/json": {
+              "schema": {
+                "$ref": "#/components/schemas/EditContractEndDate"
+              }
+            },
+            "application/*+json": {
+              "schema": {
+                "$ref": "#/components/schemas/EditContractEndDate"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Success"
+          },
+          "404": {
+            "description": "Not Found"
+          },
+          "403": {
+            "description": "Forbidden"
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "ActionTypeEnum": {
+        "enum": [
+          "Created",
+          "Accepted",
+          "Declined",
+          "Activated",
+          "Deactivated",
+          "EndDateChanged",
+          "Expired"
+        ],
+        "type": "string"
+      },
+      "ActivityLogEntryFilterRequest": {
+        "type": "object",
+        "properties": {
+          "start": {
+            "type": "integer",
+            "format": "int64",
+            "nullable": true
+          },
+          "end": {
+            "type": "integer",
+            "format": "int64",
+            "nullable": true
+          },
+          "entityType": {
+            "$ref": "#/components/schemas/EntityTypeEnum"
+          }
+        },
+        "additionalProperties": false
+      },
+      "ActivityLogEntryResponse": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "timestamp": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "actorId": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "actorType": {
+            "$ref": "#/components/schemas/ActorTypeEnum"
+          },
+          "actorName": {
+            "type": "string"
+          },
+          "organizationTin": {
+            "type": "string"
+          },
+          "organizationName": {
+            "type": "string"
+          },
+          "otherOrganizationTin": {
+            "type": "string"
+          },
+          "otherOrganizationName": {
+            "type": "string"
+          },
+          "entityType": {
+            "$ref": "#/components/schemas/EntityTypeEnum"
+          },
+          "actionType": {
+            "$ref": "#/components/schemas/ActionTypeEnum"
+          },
+          "entityId": {
+            "type": "string"
+          }
+        },
+        "additionalProperties": false
+      },
+      "ActivityLogListEntryResponse": {
+        "type": "object",
+        "properties": {
+          "activityLogEntries": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ActivityLogEntryResponse"
+            }
+          },
+          "hasMore": {
+            "type": "boolean"
+          }
+        },
+        "additionalProperties": false
+      },
+      "ActorTypeEnum": {
+        "enum": [
+          "User",
+          "System"
+        ],
+        "type": "string"
+      },
+      "Contract": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "gsrn": {
+            "type": "string",
+            "description": "Global Service Relation Number (GSRN) for the metering point"
+          },
+          "startDate": {
+            "type": "integer",
+            "description": "Starting date for generation of certificates in Unix time seconds",
+            "format": "int64"
+          },
+          "endDate": {
+            "type": "integer",
+            "description": "End date for generation of certificates in Unix time seconds. The value null indicates no end date",
+            "format": "int64",
+            "nullable": true
+          },
+          "created": {
+            "type": "integer",
+            "description": "Creation date for the contract",
+            "format": "int64"
+          },
+          "meteringPointType": {
+            "$ref": "#/components/schemas/MeteringPointType"
+          },
+          "technology": {
+            "$ref": "#/components/schemas/Technology"
+          }
+        },
+        "additionalProperties": false
+      },
+      "ContractList": {
+        "type": "object",
+        "properties": {
+          "result": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Contract"
+            }
+          }
+        },
+        "additionalProperties": false
+      },
+      "CreateContract": {
+        "type": "object",
+        "properties": {
+          "gsrn": {
+            "type": "string",
+            "description": "Global Service Relation Number (GSRN) for the metering point"
+          },
+          "startDate": {
+            "type": "integer",
+            "description": "Starting date for generation of certificates in Unix time seconds",
+            "format": "int64"
+          },
+          "endDate": {
+            "type": "integer",
+            "description": "End date for generation of certificates in Unix time seconds. Set to null for no end date",
+            "format": "int64",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "EditContractEndDate": {
+        "type": "object",
+        "properties": {
+          "endDate": {
+            "type": "integer",
+            "description": "End Date for generation of certificates in Unix time seconds. Set to null for no end date",
+            "format": "int64",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "EntityTypeEnum": {
+        "enum": [
+          "TransferAgreement",
+          "TransferAgreementProposal",
+          "MeteringPoint"
+        ],
+        "type": "string"
+      },
+      "MeteringPointType": {
+        "enum": [
+          "Production",
+          "Consumption"
+        ],
+        "type": "string"
+      },
+      "Technology": {
+        "type": "object",
+        "properties": {
+          "fuelCode": {
+            "type": "string"
+          },
+          "techCode": {
+            "type": "string"
+          }
+        },
+        "additionalProperties": false
+      },
+      "ValidationProblemDetails": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string",
+            "nullable": true
+          },
+          "title": {
+            "type": "string",
+            "nullable": true
+          },
+          "status": {
+            "type": "integer",
+            "format": "int32",
+            "nullable": true
+          },
+          "detail": {
+            "type": "string",
+            "nullable": true
+          },
+          "instance": {
+            "type": "string",
+            "nullable": true
+          },
+          "errors": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          }
+        },
+        "additionalProperties": { }
+      }
+    },
+    "securitySchemes": {
+      "Bearer": {
+        "type": "http",
+        "description": "JWT Authorization header using the Bearer scheme. \r\n\r\n Enter 'Bearer' [space] and then your token in the text input below.\r\n\r\nExample: \"Bearer 1safsfsdfdfd\"",
+        "scheme": "Bearer",
+        "bearerFormat": "JWT"
+      }
+    }
+  },
+  "security": [
+    {
+      "Bearer": [ ]
+    }
+  ],
+  "tags": [
+    {
+      "name": "Contracts",
+      "description": "Contracts are key in Energy Origin. When you have an active contract for at metering point Granular Certificates will be generated until the end of the contract. It applies to both production and consumption metering points. However, the production metering points must be either Wind or Solar – otherwise it is not possible to generate GCs. When a contract is inactive Granular Certificates will no longer be generated."
+    }
+  ]
+}


### PR DESCRIPTION
This PR aims to make the SwaggerDoc available as a file, directly for redoc.

This way, Redoc will not have to make a GET request to the swagger endpoint in order to Get the latest spec.

This would also later allow us to adjust the Spec, before it is created, so activitylog is not created in it.