### PR TITLE
downgrade mass transit to 8.2.0

### DIFF
--- a/libraries/dotnet/EnergyOrigin.Setup/EnergyOrigin.Setup/EnergyOrigin.Setup.csproj
+++ b/libraries/dotnet/EnergyOrigin.Setup/EnergyOrigin.Setup/EnergyOrigin.Setup.csproj
@@ -20,7 +20,7 @@
 	<ItemGroup>
 	  <PackageReference Include="Asp.Versioning.Mvc" Version="8.1.0" />
 	  <PackageReference Include="Asp.Versioning.Mvc.ApiExplorer" Version="8.1.0" />
-	  <PackageReference Include="MassTransit" Version="8.2.1" />
+	  <PackageReference Include="MassTransit" Version="8.2.0" />
 	  <PackageReference Include="Npgsql.OpenTelemetry" Version="8.0.2" />
 	  <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.8.0" />
 	  <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.8.0" />

--- a/libraries/dotnet/EnergyOrigin.Setup/configuration.yaml
+++ b/libraries/dotnet/EnergyOrigin.Setup/configuration.yaml
@@ -1,1 +1,1 @@
-version: 4.1.0
+version: 4.1.1


### PR DESCRIPTION
mass transit 8.2.1 results in a null pointer error during configuration. The 8.2.0 version used previously does not.