### PR TITLE
move test to activity log library

### DIFF
--- a/libraries/dotnet/EnergyOrigin.ActivityLog/EnergyOrigin.ActivityLog.Unit.Tests/CleanupActivityLogsHostedServiceTests.cs
+++ b/libraries/dotnet/EnergyOrigin.ActivityLog/EnergyOrigin.ActivityLog.Unit.Tests/CleanupActivityLogsHostedServiceTests.cs
@@ -1,3 +1,4 @@
+using EnergyOrigin.ActivityLog.DataContext;
 using EnergyOrigin.ActivityLog.HostedService;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
@@ -9,34 +10,76 @@ namespace EnergyOrigin.ActivityLog.Unit.Tests;
 
 public class CleanupActivityLogsHostedServiceTests
 {
+    private readonly ILogger<CleanupActivityLogsHostedService> _logger = Substitute.For<ILogger<CleanupActivityLogsHostedService>>();
+    private readonly IServiceProvider _services = Substitute.For<IServiceProvider>();
+    private readonly IServiceScopeFactory _scopeFactory = Substitute.For<IServiceScopeFactory>();
+    private readonly IServiceScope _scope = Substitute.For<IServiceScope>();
+    private readonly DbContext _dbContext = Substitute.For<DbContext>();
+    private readonly IOptions<ActivityLogOptions> _activityLogOptions = Substitute.For<IOptions<ActivityLogOptions>>();
+    private readonly CancellationTokenSource _cancellationTokenSource = new();
 
     [Fact]
     public async Task ExecuteAsync_TriggersCleanupAndLogsInformation()
     {
-        var logger = Substitute.For<ILogger<CleanupActivityLogsHostedService>>();
-        var services = Substitute.For<IServiceProvider>();
-        var scopeFactory = Substitute.For<IServiceScopeFactory>();
-        var scope = Substitute.For<IServiceScope>();
-        var dbContext = Substitute.For<DbContext>();
-        var activityLogOptions = Substitute.For<IOptions<ActivityLogOptions>>();
-        var cancellationTokenSource = new CancellationTokenSource();
-
-        activityLogOptions.Value.Returns(new ActivityLogOptions
+        _activityLogOptions.Value.Returns(new ActivityLogOptions
         {
             CleanupActivityLogsOlderThanInDays = 30,
             CleanupIntervalInSeconds = 1
         });
 
-        services.GetService(typeof(IServiceScopeFactory)).Returns(scopeFactory);
-        scopeFactory.CreateScope().Returns(scope);
-        scope.ServiceProvider.GetService(typeof(DbContext)).Returns(dbContext);
+        _services.GetService(typeof(IServiceScopeFactory)).Returns(_scopeFactory);
+        _scopeFactory.CreateScope().Returns(_scope);
+        _scope.ServiceProvider.GetService(typeof(DbContext)).Returns(_dbContext);
 
-        var service = new CleanupActivityLogsHostedService(logger, services, activityLogOptions);
+        var service = new CleanupActivityLogsHostedService(_logger, _services, _activityLogOptions);
 
-        cancellationTokenSource.CancelAfter(1500);
-        await service.StartAsync(cancellationTokenSource.Token);
+        _cancellationTokenSource.CancelAfter(1500);
+        await service.StartAsync(_cancellationTokenSource.Token);
 
-        logger.ReceivedWithAnyArgs().LogInformation(default);
+        _logger.ReceivedWithAnyArgs().LogInformation(default);
+    }
+
+    [Fact]
+    public async Task GivenActivityLogEntries_WhenCleaningUpOldEntries_EntriesAreRemoved()
+    {
+        var options = new DbContextOptionsBuilder<TestDbContext>()
+            .UseInMemoryDatabase(databaseName: "TestDb_GetActivityLogAsync") // Ensure unique name for parallel test execution
+            .Options;
+        await using var dbContext = new TestDbContext(options);
+
+        await dbContext.ActivityLogEntries.AddAsync(ActivityLogEntry.Create(Guid.NewGuid(), ActivityLogEntry.ActorTypeEnum.User, "a", "12345678", "b",
+            "87654321", "c", ActivityLogEntry.EntityTypeEnum.TransferAgreement, ActivityLogEntry.ActionTypeEnum.Deactivated, "123"));
+
+        _activityLogOptions.Value.Returns(new ActivityLogOptions
+        {
+            CleanupActivityLogsOlderThanInDays = -1,
+            CleanupIntervalInSeconds = 1
+        });
+
+        _services.GetService(typeof(IServiceScopeFactory)).Returns(_scopeFactory);
+        _scopeFactory.CreateScope().Returns(_scope);
+        _scope.ServiceProvider.GetService(typeof(DbContext)).Returns(dbContext);
+
+        var service = new CleanupActivityLogsHostedService(_logger, _services, _activityLogOptions);
+
+        var timeout = 1500;
+        _cancellationTokenSource.CancelAfter(timeout);
+        await service.StartAsync(_cancellationTokenSource.Token);
+        await WaitForCancellation(_cancellationTokenSource, timeout);
+
+        await using var newDbContext = new TestDbContext(options);
+        Assert.Empty(newDbContext.ActivityLogEntries);
+    }
+
+    private async Task WaitForCancellation(CancellationTokenSource tokenSource, int timeout)
+    {
+        try
+        {
+            await Task.Delay(timeout, tokenSource.Token);
+        }
+        catch (TaskCanceledException)
+        {
+            // Ignore
+        }
     }
 }
-

--- a/libraries/dotnet/EnergyOrigin.ActivityLog/configuration.yaml
+++ b/libraries/dotnet/EnergyOrigin.ActivityLog/configuration.yaml
@@ -1,1 +1,1 @@
-version: 5.1.4
+version: 5.1.5


### PR DESCRIPTION
Corresponding test in domain projects can now be removed.