### PR TITLE
update b2c handling with HTTP forbidden code

### DIFF
--- a/libraries/dotnet/EnergyOrigin.TokenValidation/EnergyOrigin.TokenValidation/B2C/IdentityDescriptor.cs
+++ b/libraries/dotnet/EnergyOrigin.TokenValidation/EnergyOrigin.TokenValidation/B2C/IdentityDescriptor.cs
@@ -19,7 +19,8 @@ public class IdentityDescriptor
 
         if (!OrgIds.Contains(orgId))
         {
-            throw new InvalidOperationException("IdentityDescriptor not supported");
+            httpContext.Response.StatusCode = StatusCodes.Status403Forbidden;
+            httpContext.Response.WriteAsJsonAsync("");
         }
     }
 

--- a/libraries/dotnet/EnergyOrigin.TokenValidation/EnergyOrigin.TokenValidation/Utilities/UserDescriptor.cs
+++ b/libraries/dotnet/EnergyOrigin.TokenValidation/EnergyOrigin.TokenValidation/Utilities/UserDescriptor.cs
@@ -88,16 +88,4 @@ public class UserDescriptor
             throw new PropertyMissingException(nameof(Organization));
         }
     }
-
-    public static bool IsSupported(HttpContext httpContext)
-    {
-        var usedAuthenticationScheme = GetUsedAuthenticationScheme(httpContext);
-        var tokenValidationScheme = AuthenticationScheme.TokenValidation;
-        return usedAuthenticationScheme == tokenValidationScheme;
-    }
-
-    private static string? GetUsedAuthenticationScheme(HttpContext httpContext)
-    {
-        return httpContext.Features.Get<IAuthenticateResultFeature>()?.AuthenticateResult?.Ticket?.AuthenticationScheme;
-    }
 }

--- a/libraries/dotnet/EnergyOrigin.TokenValidation/configuration.yaml
+++ b/libraries/dotnet/EnergyOrigin.TokenValidation/configuration.yaml
@@ -1,1 +1,1 @@
-version: 3.4.0
+version: 3.4.1


### PR DESCRIPTION
IdentityDescriptor will now write a 403 Forbidden response if requested organization id is not listed in organizations claim.