### PR TITLE
configure custom policies to use new eo domain

### DIFF
--- a/domains/authorization/documentation/custom_policies/B2C_1A_ClientCredentials.XML
+++ b/domains/authorization/documentation/custom_policies/B2C_1A_ClientCredentials.XML
@@ -161,7 +161,7 @@
                     <DisplayName>Check that the user has entered a valid access code by using Claims Transformations</DisplayName>
                     <Protocol Name="Proprietary" Handler="Web.TPEngine.Providers.RestfulProvider, Web.TPEngine, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null" />
                     <Metadata>
-                        <Item Key="ServiceUrl">https://authstage.at.energioprindelse.dk/api/authorization/client-consent</Item>
+                        <Item Key="ServiceUrl">https://demo.energytrackandtrace.dk/api/authorization/client-consent</Item>
                         <Item Key="SendClaimsIn">Body</Item>
                         <Item Key="AuthenticationType">Bearer</Item>
                         <Item Key="UseClaimAsBearerToken">self_access_token</Item>

--- a/domains/authorization/documentation/custom_policies/B2C_1A_MitID.XML
+++ b/domains/authorization/documentation/custom_policies/B2C_1A_MitID.XML
@@ -522,7 +522,7 @@
                     <DisplayName>Check that the user has entered a valid access code by using Claims Transformations</DisplayName>
                     <Protocol Name="Proprietary" Handler="Web.TPEngine.Providers.RestfulProvider, Web.TPEngine, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null" />
                     <Metadata>
-                        <Item Key="ServiceUrl">https://authstage.at.energioprindelse.dk/api/authorization/user-consent</Item>
+                        <Item Key="ServiceUrl">https://demo.energytrackandtrace.dk/api/authorization/user-consent</Item>
                         <Item Key="SendClaimsIn">Body</Item>
                         <Item Key="AuthenticationType">Bearer</Item>
                         <Item Key="UseClaimAsBearerToken">self_access_token</Item>


### PR DESCRIPTION
Change B2C dev instance to point to authorization API at demo.energytrackandtrace.dk.