### PR TITLE
add sub_type claim mapping

### DIFF
--- a/domains/authorization/Authorization.API/API.IntegrationTests/API.IntegrationTests/Setup/TestWebApplicationFactory.cs
+++ b/domains/authorization/Authorization.API/API.IntegrationTests/API.IntegrationTests/Setup/TestWebApplicationFactory.cs
@@ -71,26 +71,26 @@ public class TestWebApplicationFactory : WebApplicationFactory<Program>, IAsyncL
         authenticationSchemeProvider.AddScheme(b2CClientCredentialsScheme);
     }
 
-    public Api CreateApi(string sub = "", string name = "", string orgIds = "", string subType = "")
+    public Api CreateApi(string sub = "", string name = "", string orgIds = "", string subType = "", string orgCvr = "12345678")
     {
         sub = string.IsNullOrEmpty(sub) ? Guid.NewGuid().ToString() : sub;
         name = string.IsNullOrEmpty(name) ? "Test Testesen" : name;
         orgIds = string.IsNullOrEmpty(orgIds) ? Guid.NewGuid().ToString() : orgIds;
         subType = string.IsNullOrEmpty(subType) ? "user" : subType;
 
-        return new Api(CreateAuthenticatedClient(sub, name, orgIds, subType));
+        return new Api(CreateAuthenticatedClient(sub, name, orgIds, subType, orgCvr));
     }
 
-    private HttpClient CreateAuthenticatedClient(string sub, string name, string orgIds, string subType)
+    private HttpClient CreateAuthenticatedClient(string sub, string name, string orgIds, string subType, string orgCvr)
     {
         var httpClient = CreateClient();
-        var token = GenerateToken(sub, name, orgIds, subType);
+        var token = GenerateToken(sub, name, orgIds, subType, orgCvr);
         httpClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
         httpClient.DefaultRequestHeaders.Add("EO_API_VERSION", ApiVersions.Version20230101);
         return httpClient;
     }
 
-    private string GenerateToken(string sub, string name, string orgIds, string subType)
+    private string GenerateToken(string sub, string name, string orgIds, string subType, string orgCvr)
     {
         using RSA rsa = RSA.Create(2048 * 2);
         var req = new CertificateRequest("cn=eotest", rsa, HashAlgorithmName.SHA256, RSASignaturePadding.Pkcs1);
@@ -107,6 +107,7 @@ public class TestWebApplicationFactory : WebApplicationFactory<Program>, IAsyncL
             new("name", name),
             new("org_ids", orgIds),
             new("sub_type", subType),
+            new("org_cvr", orgCvr)
         });
         var securityTokenDescriptor = new SecurityTokenDescriptor
         {

--- a/domains/authorization/Authorization.API/API/Authorization/Controllers/ConsentController.cs
+++ b/domains/authorization/Authorization.API/API/Authorization/Controllers/ConsentController.cs
@@ -14,7 +14,8 @@ namespace API.Authorization.Controllers;
 
 [ApiController]
 [ApiVersion(ApiVersions.Version20230101)]
-[Authorize(Policy = Policy.B2CSubTypeUserPolicy)]
+[Authorize(Policy.B2CCvrClaim)]
+[Authorize(Policy.B2CSubTypeUserPolicy)]
 public class ConsentController : ControllerBase
 {
     private readonly IMediator _mediator;
@@ -33,7 +34,7 @@ public class ConsentController : ControllerBase
     [Route("api/authorization/consent/grant/")]
     public async Task<ActionResult> GrantConsent([FromServices] ILogger<ConsentController> logger, [FromBody] GrantConsentRequest request)
     {
-        await _mediator.Send(new GrantConsentCommand(_entityDescriptor.Sub, _entityDescriptor.OrgIds.First(),
+        await _mediator.Send(new GrantConsentCommand(_entityDescriptor.Sub, _entityDescriptor.OrgIds.Single(),
             new IdpClientId(request.IdpClientId)));
         return Ok();
     }

--- a/domains/authorization/custom_policies/B2C_1A_ClientCredentials.XML
+++ b/domains/authorization/custom_policies/B2C_1A_ClientCredentials.XML
@@ -271,6 +271,7 @@
                 <OutputClaim ClaimTypeReferenceId="org_ids_string" PartnerClaimType="org_ids"/>
                 <OutputClaim ClaimTypeReferenceId="mapped_sub" PartnerClaimType="sub"/>
                 <OutputClaim ClaimTypeReferenceId="scope"/>
+                <OutputClaim ClaimTypeReferenceId="sub_type"/>
             </OutputClaims>
             <SubjectNamingInfo ClaimType="sub"/>
         </TechnicalProfile>

--- a/domains/authorization/custom_policies/B2C_1A_MitID.XML
+++ b/domains/authorization/custom_policies/B2C_1A_MitID.XML
@@ -561,6 +561,7 @@
                 <OutputClaim ClaimTypeReferenceId="org_ids_string" PartnerClaimType="org_ids"/>
                 <OutputClaim ClaimTypeReferenceId="mapped_sub" PartnerClaimType="sub"/>
                 <OutputClaim ClaimTypeReferenceId="scope"/>
+                <OutputClaim ClaimTypeReferenceId="sub_type"/>
             </OutputClaims>
             <SubjectNamingInfo ClaimType="sub"/>
         </TechnicalProfile>

--- a/domains/authorization/custom_policies/B2C_1A_OidcMock.XML
+++ b/domains/authorization/custom_policies/B2C_1A_OidcMock.XML
@@ -310,7 +310,7 @@
     <RelyingParty>
         <DefaultUserJourney ReferenceId="OidcMockJourney"/>
         <UserJourneyBehaviors>
-            <JourneyInsights TelemetryEngine="ApplicationInsights" InstrumentationKey="12622adc-07e1-4a7f-a7e9-b93525d4ee78" DeveloperMode="true"
+            <JourneyInsights TelemetryEngine="ApplicationInsights" InstrumentationKey="126..." DeveloperMode="true"
                              ClientEnabled="true" ServerEnabled="true" TelemetryVersion="1.0.0"/>
         </UserJourneyBehaviors>
         <TechnicalProfile Id="HelloWorldPolicyProfile">
@@ -323,6 +323,7 @@
                 <OutputClaim ClaimTypeReferenceId="org_ids"/>
                 <OutputClaim ClaimTypeReferenceId="mapped_sub" PartnerClaimType="sub"/>
                 <OutputClaim ClaimTypeReferenceId="scope" DefaultValue="dashboard production meters certificates wallet"/>
+                <OutputClaim ClaimTypeReferenceId="sub_type" DefaultValue="User"/>
             </OutputClaims>
             <SubjectNamingInfo ClaimType="sub"/>
         </TechnicalProfile>


### PR DESCRIPTION
change grant consent endpoint to accept only tokens with cvr claim, and fail if not exactly one organization id in org_ids claim.