### PR TITLE
Add missing metering point options to certificates

### DIFF
--- a/domains/certificates/Query.API/API/Program.cs
+++ b/domains/certificates/Query.API/API/Program.cs
@@ -45,6 +45,8 @@ builder.Services.AddOptions<OtlpOptions>().BindConfiguration(OtlpOptions.Prefix)
 builder.Services.AddOptions<StampOptions>().BindConfiguration(StampOptions.Stamp).ValidateDataAnnotations()
     .ValidateOnStart();
 
+builder.Services.AddMeteringPointsOptions();
+
 builder.Services.Configure<RabbitMqOptions>(
     builder.Configuration.GetSection(RabbitMqOptions.RabbitMq));
 


### PR DESCRIPTION
Fixes this:

![image](https://github.com/user-attachments/assets/ddd56137-d328-437d-8089-03451261c7f7)
