### PR TITLE
Add sunset header to deprecated versions

### DIFF
--- a/domains/libraries/EnergyOrigin.Setup/EnergyOrigin.Setup/ServiceCollectionExtensions.cs
+++ b/domains/libraries/EnergyOrigin.Setup/EnergyOrigin.Setup/ServiceCollectionExtensions.cs
@@ -32,6 +32,12 @@ public static class ServiceCollectionExtensions
                 options.AssumeDefaultVersionWhenUnspecified = false;
                 options.ReportApiVersions = true;
                 options.ApiVersionReader = new HeaderApiVersionReader("X-API-Version");
+
+                options.Policies.Sunset(int.Parse(ApiVersions.Version20230101))
+                    .Effective(new DateTimeOffset(2025, 03, 23, 0, 0 ,0, TimeSpan.Zero));
+
+                options.Policies.Sunset(int.Parse(ApiVersions.Version20240515))
+                    .Effective(new DateTimeOffset(2025, 03, 23, 0, 0 ,0, TimeSpan.Zero));
             })
             .AddMvc()
             .AddApiExplorer();

--- a/domains/libraries/EnergyOrigin.Setup/EnergyOrigin.Setup/ServiceCollectionExtensions.cs
+++ b/domains/libraries/EnergyOrigin.Setup/EnergyOrigin.Setup/ServiceCollectionExtensions.cs
@@ -34,10 +34,10 @@ public static class ServiceCollectionExtensions
                 options.ApiVersionReader = new HeaderApiVersionReader("X-API-Version");
 
                 options.Policies.Sunset(int.Parse(ApiVersions.Version20230101))
-                    .Effective(new DateTimeOffset(2025, 03, 23, 0, 0 ,0, TimeSpan.Zero));
+                    .Effective(new DateTimeOffset(2025, 03, 23, 0, 0, 0, TimeSpan.Zero));
 
                 options.Policies.Sunset(int.Parse(ApiVersions.Version20240515))
-                    .Effective(new DateTimeOffset(2025, 03, 23, 0, 0 ,0, TimeSpan.Zero));
+                    .Effective(new DateTimeOffset(2025, 03, 23, 0, 0, 0, TimeSpan.Zero));
             })
             .AddMvc()
             .AddApiExplorer();


### PR DESCRIPTION
What the response looks like:

<img width="1072" alt="image" src="https://github.com/user-attachments/assets/baac9377-da5d-46e5-82f0-3770e822d786">
