### PR TITLE
This excludes the redoc folder as it is not a dotnet solution

### DIFF
--- a/.github/workflows/cron-healthcheck.yaml
+++ b/.github/workflows/cron-healthcheck.yaml
@@ -19,7 +19,7 @@ jobs:
       - name: Build subsystems matrix
         shell: bash
         run: |
-          for subsystem in $(find domains/ -mindepth 1 -maxdepth 1 -type d); do
+          for subsystem in $(find domains/ -mindepth 1 -maxdepth 1 -type d | egrep -v '/redoc$'); do
             [ -f "$subsystem/global.json" ] || cp "$subsystem/../../global.json" "$subsystem/global.json"
             settings=$(jq -srec '.[0] | .path=$path' --arg path "$subsystem" "$subsystem/global.json")
             sdk=$(printf '%s' "$settings" | jq -rce '.sdk.version')


### PR DESCRIPTION
Every day we are being spammed with issues in GH telling us our health check has failed. this is because it is trying to build redoc as a dotnet project. This PR will exclude redoc from the build matrix, and will make the cronjob work once again.

![image](https://github.com/user-attachments/assets/649a9e9b-8399-46fc-b7b7-df60dba5b63f)
