### PR TITLE
test flaky test

### DIFF
--- a/domains/certificates/Query.API/API.UnitTests/ValueObjects/UnixTimestampTest.cs
+++ b/domains/certificates/Query.API/API.UnitTests/ValueObjects/UnixTimestampTest.cs
@@ -51,6 +51,7 @@ public class UnixTimestampTest
         Assert.Equal(UnixTimestamp.Create(alignedHour), UnixTimestamp.Create(alignedHour).RoundToLatestHour());
     }
 
+    // This test is potentially flaky
     [Fact]
     public void RoundToNextHourExamples()
     {

--- a/domains/certificates/Query.API/API.UnitTests/ValueObjects/UnixTimestampTest.cs
+++ b/domains/certificates/Query.API/API.UnitTests/ValueObjects/UnixTimestampTest.cs
@@ -51,12 +51,14 @@ public class UnixTimestampTest
         Assert.Equal(UnixTimestamp.Create(alignedHour), UnixTimestamp.Create(alignedHour).RoundToLatestHour());
     }
 
-    // This test is potentially flaky
     [Fact]
     public void RoundToNextHourExamples()
     {
         var now = DateTimeOffset.Now;
-        var nextHour = new DateTimeOffset(now.Year, now.Month, now.Day, now.Hour + 1, 0, 0, now.Offset);
+        var nextHour = now.Hour == 23
+            ? new DateTimeOffset(now.Year, now.Month, now.Day + 1, 0, 0, 0, now.Offset)
+            : new DateTimeOffset(now.Year, now.Month, now.Day, now.Hour + 1, 0, 0, now.Offset);
+
         Assert.Equal(UnixTimestamp.Create(nextHour), UnixTimestamp.Create(now).RoundToNextHour());
 
         var alignedHour = new DateTimeOffset(2024, 2, 24, 12, 0, 0, TimeSpan.Zero);

--- a/domains/certificates/Query.API/API.UnitTests/ValueObjects/UnixTimestampTest.cs
+++ b/domains/certificates/Query.API/API.UnitTests/ValueObjects/UnixTimestampTest.cs
@@ -54,7 +54,7 @@ public class UnixTimestampTest
     [Fact]
     public void RoundToNextHourExamples()
     {
-        var now = DateTimeOffset.Now;
+        var now = DateTimeOffset.UtcNow;
         var nextHour = now.Hour == 23
             ? new DateTimeOffset(now.Year, now.Month, now.Day + 1, 0, 0, 0, now.Offset)
             : new DateTimeOffset(now.Year, now.Month, now.Day, now.Hour + 1, 0, 0, now.Offset);


### PR DESCRIPTION
Issue: The test `RoundToNextHourExamples` was failing for me yesterday due to an invalid hour value being generated when the current time was 23:00. It incorrectly incremented the hour to 24, which is not a valid `DateTimeOffset `value, causing an `ArgumentOutOfRangeException`.

Fix: Updated the logic to handle the transition between days by resetting the hour to 0 and incrementing the day when the current hour is 23, ensuring valid `DateTimeOffset `values are used.