### PR TITLE
Update acorn actions used

### DIFF
--- a/.github/actions/dotnet-build/action.yaml
+++ b/.github/actions/dotnet-build/action.yaml
@@ -67,7 +67,7 @@ runs:
       run: wget https://raw.githubusercontent.com/Energinet-DataHub/acorn-actions/main/Dockerfile.simplified -O Dockerfile
 
     - name: Resolve image version
-      uses: Energinet-DataHub/acorn-actions/actions/docker-image-version@v2
+      uses: Energinet-DataHub/acorn-actions/actions/docker-image-version@v3
 
     - name: Resolve image name
       shell: bash
@@ -75,7 +75,7 @@ runs:
 
     - name: Verify migrations if present
       if: inputs.migrations != ''
-      uses: Energinet-Datahub/acorn-actions/actions/dotnet-verify-migrations@v2
+      uses: Energinet-Datahub/acorn-actions/actions/dotnet-verify-migrations@v3
       with:
         path: ${{ env.DIRECTORY }}
         project: ${{ inputs.project }}
@@ -84,7 +84,7 @@ runs:
         pin-version: true
 
     - name: Build image
-      uses: Energinet-Datahub/acorn-actions/actions/docker-build-and-push@v2
+      uses: Energinet-Datahub/acorn-actions/actions/docker-build-and-push@v3
       with:
         dockerfile: Dockerfile
         image-name: ${{ env.name }}
@@ -98,7 +98,7 @@ runs:
           RUNTIME_VERSION=${{ env.RUNTIME }}
 
     - name: Scan image
-      uses: Energinet-DataHub/acorn-actions/actions/docker-scan@v2
+      uses: Energinet-DataHub/acorn-actions/actions/docker-scan@v3
       with:
         image-name: ${{ env.name }}
         image-tag: ${{ env.version }}

--- a/.github/actions/dotnet-test/action.yaml
+++ b/.github/actions/dotnet-test/action.yaml
@@ -35,7 +35,7 @@ runs:
         ! test -z "${{ env.SDK }}"
 
     - name: Test
-      uses: Energinet-DataHub/acorn-actions/actions/dotnet-validate-solution@v2
+      uses: Energinet-DataHub/acorn-actions/actions/dotnet-validate-solution@v3
       with:
         path: ${{ env.DIRECTORY }}
         dotnet-version: ${{ env.SDK }}

--- a/.github/workflows/build-openapi.yaml
+++ b/.github/workflows/build-openapi.yaml
@@ -20,14 +20,14 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Resolve image version
-        uses: Energinet-DataHub/acorn-actions/actions/docker-image-version@v2
+        uses: Energinet-DataHub/acorn-actions/actions/docker-image-version@v3
 
       - name: Resolve image name
         shell: bash
         run: echo "name=$(yq '.name' 'domains/redoc/configuration.yaml')" | tee -a $GITHUB_ENV
 
       - name: Build and push Docker image
-        uses: Energinet-Datahub/acorn-actions/actions/docker-build-and-push@v2
+        uses: Energinet-Datahub/acorn-actions/actions/docker-build-and-push@v3
         with:
           dockerfile: ./domains/redoc/Dockerfile
           image-name: ${{ env.name }}
@@ -36,7 +36,7 @@ jobs:
           dry-run: ${{ inputs.dry-run }}
 
       - name: Scan image
-        uses: Energinet-DataHub/acorn-actions/actions/docker-scan@v2
+        uses: Energinet-DataHub/acorn-actions/actions/docker-scan@v3
         with:
           image-name: ${{ env.name }}
           image-tag: ${{ env.version }}

--- a/.github/workflows/build-subsystems.yaml
+++ b/.github/workflows/build-subsystems.yaml
@@ -97,7 +97,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Update environment
-        uses: Energinet-DataHub/acorn-actions/actions/update-base-environment@v2
+        uses: Energinet-DataHub/acorn-actions/actions/update-base-environment@v3
         with:
           configurations: |
             domains/authorization/Authorization.API/configuration.yaml

--- a/.github/workflows/check-licenses.yml
+++ b/.github/workflows/check-licenses.yml
@@ -24,7 +24,7 @@ jobs:
 
       - name: Check license
         if: ${{ steps.diff.outputs.pattern != '' }}
-        uses: Energinet-DataHub/acorn-actions/actions/dotnet-check-license@v3
+        uses: Energinet-DataHub/acorn-actions/actions/dotnet-check-license@solutions-require-restore
         with:
           project-folder: ${{ env.solution }}
           license-mapping-file: .mapped-licenses.json

--- a/.github/workflows/check-licenses.yml
+++ b/.github/workflows/check-licenses.yml
@@ -58,3 +58,4 @@ jobs:
         with:
           project-folder: ${{ matrix.projects.project }}
           license-mapping-file: .mapped-licenses.json
+          license-ignore-file: .ignored-licenses.json

--- a/.github/workflows/check-licenses.yml
+++ b/.github/workflows/check-licenses.yml
@@ -4,10 +4,9 @@ on:
   workflow_call: {}
 
 jobs:
-  define-matrix:
+  check-licenses:
+    name: Check Licenses
     runs-on: ubuntu-latest
-    outputs:
-      matrix: ${{ env.matrix }}
 
     steps:
       - uses: CodeReaper/find-diff-action@v3
@@ -15,47 +14,18 @@ jobs:
         with:
           paths: domains/*/ libraries/*/*/
 
-      - name: Set default matrix
-        shell: bash
-        run: |
-          echo "matrix=[]" >> "$GITHUB_ENV"
-
       - uses: actions/checkout@v4
         if: ${{ steps.diff.outputs.pattern != '' }}
 
       - name: Build relevant project matrix
         if: ${{ steps.diff.outputs.pattern != '' }}
         shell: bash
-        env:
-          PATTERN: ${{ steps.diff.outputs.pattern }}
-        run: |
-          # TODO: re-enable checking Tests projects
-          find domains libraries/dotnet -name "*.csproj" -exec dirname {} \; | egrep "$PATTERN" | egrep -v 'ests$' > /tmp/list || true
-
-          if [ ! -s /tmp/list ]; then
-            exit 0
-          fi
-
-          matrix=$(cat /tmp/list | while read directory; do printf '{"project": "%s"}' "$directory"; done | jq -sc '.')
-          echo "matrix=$matrix" >> "$GITHUB_ENV"
-
-          echo '::group::Matrix'
-          echo "$matrix" | jq -r '.'
-          echo '::endgroup::'
-
-  check-licenses:
-    runs-on: ubuntu-latest
-    needs: define-matrix
-    if: ${{ needs.define-matrix.outputs.matrix != '[]' }}
-    strategy:
-      matrix:
-        projects: ${{ fromJson(needs.define-matrix.outputs.matrix) }}
-    steps:
-      - uses: actions/checkout@v4
+        run: echo "solution=$(find domains -maxdepth 1 -name "*.sln")" | tee -a "$GITHUB_ENV"
 
       - name: Check license
+        if: ${{ steps.diff.outputs.pattern != '' }}
         uses: Energinet-DataHub/acorn-actions/actions/dotnet-check-license@v3
         with:
-          project-folder: ${{ matrix.projects.project }}
+          project-folder: ${{ env.solution }}
           license-mapping-file: .mapped-licenses.json
           license-ignore-file: .ignored-licenses.json

--- a/.github/workflows/check-licenses.yml
+++ b/.github/workflows/check-licenses.yml
@@ -5,7 +5,6 @@ on:
 
 jobs:
   check-licenses:
-    name: Check Licenses
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/check-licenses.yml
+++ b/.github/workflows/check-licenses.yml
@@ -54,7 +54,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Check license
-        uses: Energinet-DataHub/acorn-actions/actions/dotnet-check-license@v2
+        uses: Energinet-DataHub/acorn-actions/actions/dotnet-check-license@update-check-license-action
         with:
           project-folder: ${{ matrix.projects.project }}
           license-mapping-file: .mapped-licenses.json

--- a/.github/workflows/check-licenses.yml
+++ b/.github/workflows/check-licenses.yml
@@ -54,7 +54,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Check license
-        uses: Energinet-DataHub/acorn-actions/actions/dotnet-check-license@update-check-license-action
+        uses: Energinet-DataHub/acorn-actions/actions/dotnet-check-license@v3
         with:
           project-folder: ${{ matrix.projects.project }}
           license-mapping-file: .mapped-licenses.json

--- a/.github/workflows/check-licenses.yml
+++ b/.github/workflows/check-licenses.yml
@@ -24,7 +24,7 @@ jobs:
 
       - name: Check license
         if: ${{ steps.diff.outputs.pattern != '' }}
-        uses: Energinet-DataHub/acorn-actions/actions/dotnet-check-license@solutions-require-restore
+        uses: Energinet-DataHub/acorn-actions/actions/dotnet-check-license@v3
         with:
           project-folder: ${{ env.solution }}
           license-mapping-file: .mapped-licenses.json

--- a/.github/workflows/cron-healthcheck.yaml
+++ b/.github/workflows/cron-healthcheck.yaml
@@ -46,7 +46,7 @@ jobs:
         run: echo "solution=$(find domains -maxdepth 1 -name "*.sln")" | tee -a "$GITHUB_ENV"
 
       - name: Check license
-        uses: Energinet-DataHub/acorn-actions/actions/dotnet-check-license@v3
+        uses: Energinet-DataHub/acorn-actions/actions/dotnet-check-license@solutions-require-restore
         with:
           project-folder: ${{ env.solution }}
           license-mapping-file: .mapped-licenses.json

--- a/.github/workflows/cron-healthcheck.yaml
+++ b/.github/workflows/cron-healthcheck.yaml
@@ -11,7 +11,6 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       subsystems: ${{ env.subsystems }}
-      nugets: ${{ env.nugets }}
       dockers: ${{ env.dockers }}
     steps:
       - uses: actions/checkout@v4
@@ -30,13 +29,28 @@ jobs:
           done | jq -sc > /tmp/json
           echo "subsystems=$(jq '.[].projects[]' /tmp/json | jq -scr '. | unique')" >> "$GITHUB_ENV"
 
-      - name: Build nugets matrix
-        shell: bash
-        run: echo "nugets=$(find libraries/dotnet -name "*.csproj" ! -name "*.Tests.csproj" -exec dirname {} \; | jq -nRc '[inputs]')" >> "$GITHUB_ENV"
-
       - name: Build dockers matrix
         shell: bash
         run: echo "dockers=$(find libraries/docker/ -mindepth 1 -maxdepth 1 -type d | jq -nRc '[inputs]')" >> "$GITHUB_ENV"
+
+  test-licenses:
+    name: Test licenses
+    runs-on: ubuntu-latest
+    needs: setup
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Resolve
+        shell: bash
+        run: echo "solution=$(find domains -maxdepth 1 -name "*.sln")" | tee -a "$GITHUB_ENV"
+
+      - name: Check license
+        uses: Energinet-DataHub/acorn-actions/actions/dotnet-check-license@v3
+        with:
+          project-folder: ${{ env.solution }}
+          license-mapping-file: .mapped-licenses.json
+          license-ignore-file: .ignored-licenses.json
 
   test-subsystems:
     name: Test subsystems
@@ -87,13 +101,6 @@ jobs:
           paths: ${{ env.paths }}
           sql-file: ${{ env.migration }}
 
-      - name: Check license
-        uses: Energinet-DataHub/acorn-actions/actions/dotnet-check-license@v3
-        with:
-          project-folder: ${{ env.path }}
-          license-mapping-file: .mapped-licenses.json
-          license-ignore-file: .ignored-licenses.json
-
   test-dockers:
     name: Test dockers
     runs-on: ubuntu-latest
@@ -134,6 +141,7 @@ jobs:
     needs:
       - test-subsystems
       - test-dockers
+      - test-licenses
     name: Report on failure
     runs-on: ubuntu-latest
     if: ${{ always() && contains(join(needs.*.result, ','), 'failure') }}

--- a/.github/workflows/cron-healthcheck.yaml
+++ b/.github/workflows/cron-healthcheck.yaml
@@ -80,7 +80,7 @@ jobs:
           } >> $GITHUB_ENV
 
       - name: Validate project
-        uses: Energinet-DataHub/acorn-actions/actions/dotnet-validate@v2
+        uses: Energinet-DataHub/acorn-actions/actions/dotnet-validate@v3
         with:
           dotnet-version: ${{ matrix.build.sdkVersion }}
           pin-version: true
@@ -88,7 +88,7 @@ jobs:
           sql-file: ${{ env.migration }}
 
       - name: Check license
-        uses: Energinet-DataHub/acorn-actions/actions/dotnet-check-license@update-check-license-action
+        uses: Energinet-DataHub/acorn-actions/actions/dotnet-check-license@v3
         with:
           project-folder: ${{ env.path }}
           license-mapping-file: .mapped-licenses.json
@@ -122,7 +122,7 @@ jobs:
           } >> "$GITHUB_ENV"
 
       - name: Push image
-        uses: Energinet-DataHub/acorn-actions/actions/docker-build-and-push@v2
+        uses: Energinet-DataHub/acorn-actions/actions/docker-build-and-push@v3
         with:
           dockerfile: ${{ env.docker }}
           image-name: ${{ env.name }}

--- a/.github/workflows/cron-healthcheck.yaml
+++ b/.github/workflows/cron-healthcheck.yaml
@@ -92,6 +92,7 @@ jobs:
         with:
           project-folder: ${{ env.path }}
           license-mapping-file: .mapped-licenses.json
+          license-ignore-file: .ignored-licenses.json
 
   test-dockers:
     name: Test dockers

--- a/.github/workflows/cron-healthcheck.yaml
+++ b/.github/workflows/cron-healthcheck.yaml
@@ -88,7 +88,7 @@ jobs:
           sql-file: ${{ env.migration }}
 
       - name: Check license
-        uses: Energinet-DataHub/acorn-actions/actions/dotnet-check-license@v2
+        uses: Energinet-DataHub/acorn-actions/actions/dotnet-check-license@update-check-license-action
         with:
           project-folder: ${{ env.path }}
           license-mapping-file: .mapped-licenses.json

--- a/.github/workflows/cron-healthcheck.yaml
+++ b/.github/workflows/cron-healthcheck.yaml
@@ -46,7 +46,7 @@ jobs:
         run: echo "solution=$(find domains -maxdepth 1 -name "*.sln")" | tee -a "$GITHUB_ENV"
 
       - name: Check license
-        uses: Energinet-DataHub/acorn-actions/actions/dotnet-check-license@solutions-require-restore
+        uses: Energinet-DataHub/acorn-actions/actions/dotnet-check-license@v3
         with:
           project-folder: ${{ env.solution }}
           license-mapping-file: .mapped-licenses.json

--- a/.ignored-licenses.json
+++ b/.ignored-licenses.json
@@ -1,0 +1,4 @@
+[
+    "jose-jwt",
+    "Microsoft.AspNet.WebApi.Client"
+]

--- a/.ignored-licenses.json
+++ b/.ignored-licenses.json
@@ -1,4 +1,8 @@
 [
     "jose-jwt",
-    "Microsoft.AspNet.WebApi.Client"
+    "MockQueryable.NSubstitute",
+    "Microsoft.AspNet.WebApi.Client",
+    "Testcontainers*",
+    "origin/*",
+    "xunit.categories"
 ]

--- a/domains/measurements/README.md
+++ b/domains/measurements/README.md
@@ -12,7 +12,6 @@ When running in k8s migrations are applied in an initContainer before the actual
 
 You must manually remember to generate the complete SQL migration script after adding a migration. The complete SQL migration script is used to migrate the database when running in k8s.
 
-
 This is the commands for generating the migration SQL script for the API project and Worker project:
 
 ```shell

--- a/domains/measurements/README.md
+++ b/domains/measurements/README.md
@@ -12,6 +12,7 @@ When running in k8s migrations are applied in an initContainer before the actual
 
 You must manually remember to generate the complete SQL migration script after adding a migration. The complete SQL migration script is used to migrate the database when running in k8s.
 
+
 This is the commands for generating the migration SQL script for the API project and Worker project:
 
 ```shell


### PR DESCRIPTION
We are ignoring these nuget packages since we do not contain license information at least not any that conforms to the tool we are checking with:
- `jose-jwt`
- `Microsoft.AspNet.WebApi.Client`

These ignored licenses have *do* have licenses that are in the allowed licenses file. We just cannot automate checking them.

They should properly be checked for alternatives that can be validated, or perhaps make pull requests to them so they can be fixed.

Also note, that no nuget packages used in test projects are validated still - there is a TODO about re-enabling them.