### PR TITLE
only-delete-contracts-that-have-crossed-age-threshold

### DIFF
--- a/domains/certificates/Query.API/API.IntegrationTests/IssuingContractCleanup/IssuingContractCleanupTests.cs
+++ b/domains/certificates/Query.API/API.IntegrationTests/IssuingContractCleanup/IssuingContractCleanupTests.cs
@@ -1,13 +1,17 @@
 using System;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
-using API.IntegrationTests.Extensions;
+using API.Configurations;
+using API.IssuingContractCleanup;
 using DataContext;
 using DataContext.Models;
 using DataContext.ValueObjects;
 using EnergyTrackAndTrace.Testing.Testcontainers;
 using FluentAssertions;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
 using Xunit;
 
 namespace API.IntegrationTests.IssuingContractCleanup;
@@ -23,69 +27,145 @@ public class IssuingContractCleanupTests
     }
 
     [Fact]
-    public async Task ShouldOnlyDeleteExpiredIssuingContracts()
+    public async Task IssuingContractCleanup_WithZeroMinimumAgeThreshold_ShouldDeleteContractsEndingBeforeNow()
     {
+        // Arrange
         var dbContext = GetDbContext();
-
         dbContext.Contracts.RemoveRange(dbContext.Contracts);
         await dbContext.SaveChangesAsync();
 
+        var options = Options.Create(new MeasurementsSyncOptions
+        {
+            MinimumAgeThresholdHours = 0
+        });
+
+        var logger = new NullLogger<IssuingContractCleanupService>();
+
+        var service = new IssuingContractCleanupService(dbContext, logger, options);
+
         var expiredContract = new CertificateIssuingContract
         {
+            Id = Guid.NewGuid(),
             GSRN = "5734567890123456",
             EndDate = DateTimeOffset.UtcNow.AddHours(-1),
             MeteringPointOwner = Guid.NewGuid().ToString(),
             ContractNumber = 0,
             Created = DateTimeOffset.UtcNow.AddHours(-2),
             GridArea = "DK1",
-            Id = Guid.NewGuid(),
             MeteringPointType = MeteringPointType.Production,
             StartDate = DateTimeOffset.UtcNow.AddHours(-2),
             Technology = new Technology("SomeFuelCode", "SomeTechCode"),
             RecipientId = Guid.NewGuid()
         };
-        var nullEndDateContract = new CertificateIssuingContract
+
+        var activeContract = new CertificateIssuingContract
         {
+            Id = Guid.NewGuid(),
             GSRN = "5734567890123457",
-            EndDate = null,
-            MeteringPointOwner = Guid.NewGuid().ToString(),
-            ContractNumber = 1,
-            Created = DateTimeOffset.UtcNow.AddHours(-2),
-            GridArea = "DK1",
-            Id = Guid.NewGuid(),
-            MeteringPointType = MeteringPointType.Production,
-            StartDate = DateTimeOffset.UtcNow.AddHours(-2),
-            Technology = new Technology("SomeFuelCode", "SomeTechCode"),
-            RecipientId = Guid.NewGuid()
-        };
-        var endDateContract = new CertificateIssuingContract
-        {
-            GSRN = "5734567890123458",
             EndDate = DateTimeOffset.UtcNow.AddHours(1),
             MeteringPointOwner = Guid.NewGuid().ToString(),
+            ContractNumber = 1,
+            Created = DateTimeOffset.UtcNow.AddHours(-1),
+            GridArea = "DK1",
+            MeteringPointType = MeteringPointType.Production,
+            StartDate = DateTimeOffset.UtcNow.AddHours(-1),
+            Technology = new Technology("SomeFuelCode", "SomeTechCode"),
+            RecipientId = Guid.NewGuid()
+        };
+
+        dbContext.Contracts.AddRange(expiredContract, activeContract);
+        await dbContext.SaveChangesAsync();
+
+        // Act
+        await service.RunCleanupJob(CancellationToken.None);
+
+        // Assert
+        var remainingContracts = dbContext.Contracts.ToList();
+        remainingContracts.Count.Should().Be(1);
+        remainingContracts.Single().Id.Should().Be(activeContract.Id);
+    }
+
+    [Fact]
+    public async Task IssuingContractCleanup_WithMinimumAgeThreshold_ShouldDeleteContractsOlderThanThreshold()
+    {
+        // Arrange
+        var dbContext = GetDbContext();
+        dbContext.Contracts.RemoveRange(dbContext.Contracts);
+        await dbContext.SaveChangesAsync();
+
+        var options = Options.Create(new MeasurementsSyncOptions
+        {
+            MinimumAgeThresholdHours = 2
+        });
+
+        var logger = new NullLogger<IssuingContractCleanupService>();
+
+        var service = new IssuingContractCleanupService(dbContext, logger, options);
+
+        var contractToDelete = new CertificateIssuingContract
+        {
+            Id = Guid.NewGuid(),
+            GSRN = "5734567890123458",
+            EndDate = DateTimeOffset.UtcNow.AddHours(-3),
+            MeteringPointOwner = Guid.NewGuid().ToString(),
             ContractNumber = 2,
+            Created = DateTimeOffset.UtcNow.AddHours(-4),
+            GridArea = "DK1",
+            MeteringPointType = MeteringPointType.Production,
+            StartDate = DateTimeOffset.UtcNow.AddHours(-4),
+            Technology = new Technology("SomeFuelCode", "SomeTechCode"),
+            RecipientId = Guid.NewGuid()
+        };
+
+        var contractToKeep = new CertificateIssuingContract
+        {
+            Id = Guid.NewGuid(),
+            GSRN = "5734567890123459",
+            EndDate = DateTimeOffset.UtcNow.AddHours(-1),
+            MeteringPointOwner = Guid.NewGuid().ToString(),
+            ContractNumber = 3,
             Created = DateTimeOffset.UtcNow.AddHours(-2),
             GridArea = "DK1",
-            Id = Guid.NewGuid(),
             MeteringPointType = MeteringPointType.Production,
             StartDate = DateTimeOffset.UtcNow.AddHours(-2),
             Technology = new Technology("SomeFuelCode", "SomeTechCode"),
             RecipientId = Guid.NewGuid()
         };
-        dbContext.Contracts.AddRange(expiredContract, nullEndDateContract, endDateContract);
+
+        var futureContract = new CertificateIssuingContract
+        {
+            Id = Guid.NewGuid(),
+            GSRN = "5734567890123460",
+            EndDate = DateTimeOffset.UtcNow.AddHours(2),
+            MeteringPointOwner = Guid.NewGuid().ToString(),
+            ContractNumber = 4,
+            Created = DateTimeOffset.UtcNow.AddHours(-1),
+            GridArea = "DK1",
+            MeteringPointType = MeteringPointType.Production,
+            StartDate = DateTimeOffset.UtcNow.AddHours(-1),
+            Technology = new Technology("SomeFuelCode", "SomeTechCode"),
+            RecipientId = Guid.NewGuid()
+        };
+
+        dbContext.Contracts.AddRange(contractToDelete, contractToKeep, futureContract);
         await dbContext.SaveChangesAsync();
 
-        var contracts = await dbContext.RepeatedlyQueryUntilCountIsMet<CertificateIssuingContract>(2);
+        // Act
+        await service.RunCleanupJob(CancellationToken.None);
 
-        contracts.Count.Should().Be(2);
-        contracts.Select(x => x.Id).Should().NotContain(expiredContract.Id);
-        contracts.Select(x => x.Id).Should().Contain(nullEndDateContract.Id);
-        contracts.Select(x => x.Id).Should().Contain(endDateContract.Id);
+        // Assert
+        var remainingContracts = dbContext.Contracts.ToList();
+        remainingContracts.Count.Should().Be(2);
+        remainingContracts.Select(c => c.Id).Should().Contain(contractToKeep.Id);
+        remainingContracts.Select(c => c.Id).Should().Contain(futureContract.Id);
+        remainingContracts.Select(c => c.Id).Should().NotContain(contractToDelete.Id);
     }
 
     private ApplicationDbContext GetDbContext()
     {
-        var contextOptions = new DbContextOptionsBuilder<ApplicationDbContext>().UseNpgsql(postgresContainer.ConnectionString).Options;
+        var contextOptions = new DbContextOptionsBuilder<ApplicationDbContext>()
+            .UseNpgsql(postgresContainer.ConnectionString)
+            .Options;
         return new ApplicationDbContext(contextOptions);
     }
 }

--- a/domains/certificates/Query.API/API/IssuingContractCleanup/Startup.cs
+++ b/domains/certificates/Query.API/API/IssuingContractCleanup/Startup.cs
@@ -1,3 +1,4 @@
+using API.Configurations;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace API.IssuingContractCleanup;
@@ -10,6 +11,8 @@ public static class Startup
             .BindConfiguration(IssuingContractCleanupOptions.Prefix)
             .ValidateDataAnnotations()
             .ValidateOnStart();
+
+        services.MeasurementsSyncOptions();
 
         services.AddScoped<IssuingContractCleanupService>();
         services.AddHostedService<IssuingContractCleanupWorker>();


### PR DESCRIPTION
Problems that need to be addressed:

- Make sure contracts are not deleted, before crossing the MinimumAgeThresholdHours
- Make sure contracts are not deleted, before all certificates required have been issued ( Imagine a scenario where the threshold has been crossed, but Datahub has been down, and thus not all required certificates have been issued)
- Make sure we don't fetch contracts outside threshold, when fetching measurements