### PR TITLE
Log errors in stamp client

### DIFF
--- a/domains/certificates/Query.API/API/ContractService/Clients/StampClient.cs
+++ b/domains/certificates/Query.API/API/ContractService/Clients/StampClient.cs
@@ -8,6 +8,7 @@ using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
 using API.Configurations;
+using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 
 namespace API.ContractService.Clients;
@@ -21,11 +22,13 @@ public interface IStampClient
 public class StampClient : IStampClient
 {
     private readonly HttpClient client;
+    private readonly ILogger<StampClient> logger;
     private readonly StampOptions options;
 
-    public StampClient(HttpClient client, IOptions<StampOptions> options)
+    public StampClient(HttpClient client, IOptions<StampOptions> options, ILogger<StampClient> logger)
     {
         this.client = client;
+        this.logger = logger;
         this.options = options.Value;
     }
 
@@ -64,7 +67,13 @@ public class StampClient : IStampClient
         {
             throw new HttpRequestException("Null response");
         }
-        responseMessage.EnsureSuccessStatusCode();
+
+        if (!responseMessage.IsSuccessStatusCode)
+        {
+            var error = await responseMessage.Content.ReadAsStringAsync(cancellationToken);
+            logger.LogError("Error response from Stamp: {Error}", error);
+            responseMessage.EnsureSuccessStatusCode();
+        }
         return (await responseMessage.Content.ReadFromJsonAsync<T>(cancellationToken))!;
     }
 }


### PR DESCRIPTION
at System.Net.Http.HttpResponseMessage.EnsureSuccessStatusCode()
at API.ContractService.Clients.StampClient.ParseResponse[T](HttpResponseMessage responseMessage, CancellationToken cancellationToken) in /src/domains/certificates/Query.API/API/ContractService/Clients/StampClient.cs:line 67
at API.ContractService.Clients.StampClient.IssueCertificate(Guid recipientId, String meteringPointId, CertificateDto certificate, CancellationToken cancellationToken) in /src/domains/certificates/Query.API/API/ContractService/Clients/StampClient.cs:line 58
...

We don't get the actual error other than status code. Stamp has several Conflict reasons: 

<img width="1540" alt="image" src="https://github.com/user-attachments/assets/07b3dd8e-12e2-4c13-a8ca-c583d108998a" />

We should log what is actually going wrong, so we can look into it.