### PR TITLE
GSRN tostring now correctly prints

### DIFF
--- a/domains/certificates/Query.API/API.UnitTests/ValueObjects/GsrnTests.cs
+++ b/domains/certificates/Query.API/API.UnitTests/ValueObjects/GsrnTests.cs
@@ -43,4 +43,14 @@ public class GsrnTests
 
         gsrn1.Equals(gsrn2).Should().BeTrue();
     }
+
+    [Fact]
+    public void ToString_CorrectlyPrints()
+    {
+        var gsrnValue = "571234567890123456";
+        var gsrn = new Gsrn(gsrnValue);
+
+        Assert.Equal(gsrnValue, gsrn.ToString());
+        Assert.Equal(gsrnValue, $"{gsrn}");
+    }
 }

--- a/domains/certificates/Shared/DataContext/ValueObjects/Gsrn.cs
+++ b/domains/certificates/Shared/DataContext/ValueObjects/Gsrn.cs
@@ -24,4 +24,9 @@ public partial class Gsrn : ValueObject
     {
         yield return Value;
     }
+
+    public override string ToString()
+    {
+        return Value;
+    }
 }


### PR DESCRIPTION
MeasurementsSyncService line 152: _logger.LogError(e, "An error occured: {error}, no measurements were published, MeteringPoint: {gsrn}", e.Message, syncInfo.Gsrn);

Prints "gsrn":"DataContext.ValueObjects.Gsrn". This should fix that.


