### PR TITLE
Exclude e2e tests on draft PR

### DIFF
--- a/.github/actions/dotnet-validate-solution/action.yaml
+++ b/.github/actions/dotnet-validate-solution/action.yaml
@@ -17,6 +17,11 @@ inputs:
     default: "false"
     required: false
 
+  test-filter:
+    description: Dotnet test filter
+    default: ""
+    required: false
+
 runs:
   using: composite
 
@@ -46,7 +51,7 @@ runs:
         dotnet tool restore || true
         dotnet restore ${{ inputs.subsystem }}.sln
 
-    - name: Test
+    - name: Test with filter
       shell: bash
       env:
         DOTNET_NOLOGO: "true"
@@ -54,4 +59,5 @@ runs:
         DOTNET_SYSTEM_CONSOLE_ALLOW_ANSI_COLOR_REDIRECTION: "true"
         TERM: "xterm"
         version: ""
-      run: dotnet test ${{ inputs.subsystem }}.sln --no-restore --configuration Release -warnaserror --logger:"console;verbosity=minimal" -p:ParallelizeAssemblies=true -p:ParallelizeTestCollections=true
+      run: dotnet test ${{ inputs.subsystem }}.sln --no-restore --configuration Release -warnaserror --logger:"console;verbosity=minimal" --filter ${{ inputs.test-filter }} -p:ParallelizeAssemblies=true -p:ParallelizeTestCollections=true
+

--- a/.github/workflows/build-subsystems.yaml
+++ b/.github/workflows/build-subsystems.yaml
@@ -23,7 +23,7 @@ jobs:
         with:
           path: "domains"
 
-  test-subsystems:
+  test-subsystems-exclude-e2e:
     runs-on: ubuntu-22.04
     strategy:
       matrix:
@@ -32,11 +32,12 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Test ${{ matrix.subsystem }} subsystem
+      - name: Test ${{ matrix.subsystem }} subsystem (excluding E2E-tests)
         uses: ./.github/actions/dotnet-validate-solution
         with:
           subsystem: ${{ matrix.subsystem }}
           pin-version: "true"
+          test-filter: "Category!=E2ETest"
 
   build-admin-portal:
     uses: ./.github/workflows/build-admin-portal.yaml
@@ -99,7 +100,7 @@ jobs:
     name: Update environment
     needs:
       - dotnet-lint-solution
-      - test-subsystems
+      - test-subsystems-exclude-e2e
       - build-admin-portal
       - build-authorization
       - build-certificates

--- a/.github/workflows/cron-b2c.yaml
+++ b/.github/workflows/cron-b2c.yaml
@@ -19,4 +19,4 @@ jobs:
           azure-client-secret: ${{ secrets.ENERGY_TRACK_AND_TRACE_B2C_CLIENT_SECRET_DEMO }}
           github-client-id: ${{ secrets.EO_BASE_ENVIRONMENT_READER_APP_ID }}
           github-client-secret: ${{ secrets.EO_BASE_ENVIRONMENT_READER_PRIVATEKEY }}
-        
+

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -1,0 +1,55 @@
+name: E2E Tests
+
+on:
+  pull_request:
+    branches:
+      - main
+    types:
+      - opened
+      - synchronize
+      - reopened
+      - ready_for_review
+  push:
+    branches:
+      - main
+
+jobs:
+  test-subsystems-e2e:
+    runs-on: ubuntu-22.04
+    if: github.event.pull_request.draft == false
+    permissions:
+      contents: read
+    strategy:
+      matrix:
+        subsystem: [admin-portal, authorization, certificates, measurements, oidc-mock, transfer]
+      fail-fast: false
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Test ${{ matrix.subsystem }} subsystem - E2E
+        uses: ./.github/actions/dotnet-validate-solution
+        with:
+          subsystem: ${{ matrix.subsystem }}
+          pin-version: "true"
+          test-filter: "Category=E2ETest"
+
+  allow-merge-e2e-tests:
+    runs-on: ubuntu-latest
+    needs:
+      [
+        test-subsystems-e2e,
+      ]
+    if: always()
+    permissions:
+      pull-requests: write
+    steps:
+      - name: Print needs
+        run: |
+          echo '${{ toJSON(needs) }}'
+      - name: Verify if merge is allowed - E2E-tests
+        run: |
+          verification=$(echo '${{ toJSON(needs) }}' | jq '.[] | select(.result != "success") | select(.result != "skipped")')
+          if [[ ! -z "$verification" ]]; then
+              echo "Failed"
+              exit 1
+          fi

--- a/domains/certificates/Query.API/API.IntegrationTests/CertificateIssuingTests.cs
+++ b/domains/certificates/Query.API/API.IntegrationTests/CertificateIssuingTests.cs
@@ -15,6 +15,7 @@ using DataContext.ValueObjects;
 using EnergyOrigin.Domain.ValueObjects;
 using EnergyOrigin.IntegrationEvents.Events.EnergyMeasured.V3;
 using EnergyOrigin.WalletClient.Models;
+using EnergyTrackAndTrace.Testing.Attributes;
 using FluentAssertions;
 using Meteringpoint.V1;
 using NSubstitute;
@@ -37,6 +38,7 @@ public sealed class CertificateIssuingTests : TestBase
     }
 
     [Fact]
+    [E2ETest]
     public async Task MeasurementsSyncerSendsMeasurementsToStamp_ExpectInWallet()
     {
         var gsrn = Any.Gsrn();

--- a/domains/libraries/EnergyTrackAndTrace.Testing/Attributes/E2ETestAttribute.cs
+++ b/domains/libraries/EnergyTrackAndTrace.Testing/Attributes/E2ETestAttribute.cs
@@ -1,0 +1,11 @@
+using System;
+using System.Collections.Generic;
+using Xunit.v3;
+
+namespace EnergyTrackAndTrace.Testing.Attributes;
+
+[AttributeUsage(AttributeTargets.Assembly | AttributeTargets.Class | AttributeTargets.Method, AllowMultiple = true)]
+public class E2ETestAttribute : Attribute, ITraitAttribute
+{
+    public IReadOnlyCollection<KeyValuePair<string, string>> GetTraits() => [new("Category", "E2ETest")];
+}


### PR DESCRIPTION
- E2E tests are running as part of a new workflow
  - They are only running when the PR is in a non draft state. I.e. ready for review