### PR TITLE
Switch to built-in health check

### DIFF
--- a/domains/admin-portal/AdminPortal.Web/AdminPortal/Program.cs
+++ b/domains/admin-portal/AdminPortal.Web/AdminPortal/Program.cs
@@ -31,7 +31,7 @@ builder.Services.AddOptions<OtlpOptions>().BindConfiguration(OtlpOptions.Prefix)
 builder.Services.AddOptions<CvrOptions>().BindConfiguration(CvrOptions.Prefix).ValidateDataAnnotations()
     .ValidateOnStart();
 
-builder.Services.AddDefaultHealthChecks();
+builder.Services.AddHealthChecks();
 
 var otlpConfiguration = builder.Configuration.GetSection(OtlpOptions.Prefix);
 var otlpOptions = otlpConfiguration.Get<OtlpOptions>()!;


### PR DESCRIPTION
- Admin-portal does not have a postgresql server. Using built-in health check which does not check for a database